### PR TITLE
Bump up kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/kotpref/build.gradle
+++ b/kotpref/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
 }
 buildscript {
-    ext.kotlin_version = '1.0.0-beta-4584'
+    ext.kotlin_version = '1.0.0-rc-1036'
     repositories {
         mavenCentral()
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile project(":kotpref")
 }
 buildscript {
-    ext.kotlin_version = '1.0.0-beta-4584'
+    ext.kotlin_version = '1.0.0-rc-1036'
     repositories {
         mavenCentral()
     }


### PR DESCRIPTION
Hi.

Kotlin 1.0 Release Candidate is Out!
http://blog.jetbrains.com/kotlin/2016/02/kotlin-1-0-release-candidate-is-out/

1.0 RC is not compatible with older version. 
So the library written by Kotlin is should update.

Thanks.