### PR TITLE
Add support for storing and retrieving properties based on enums

### DIFF
--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
@@ -149,6 +149,60 @@ abstract class KotprefModel() {
             : ReadWriteProperty<KotprefModel, Boolean> = BooleanPrefVar(default, context.getString(key))
 
     /**
+     * Delegate enum-based shared preference property storing and recalling by the enum value's name as a string.
+     * @param values Enum class to define the property
+     * @param default default enum value
+     * @param key custom preference key
+     */
+    protected fun <T : Enum<*>> enumValuePrefVar(enumClass: Class<T>, default: T, key: String? = null)
+            : ReadWriteProperty<KotprefModel, T> = EnumValuePrefVar(enumClass, default, key)
+
+    /**
+     * Delegate enum-based shared preference property storing and recalling by the enum value's name as a string.
+     * @param values Enum class to define the property
+     * @param default default enum value
+     * @param key custom preference key resource id
+     */
+    protected fun <T : Enum<*>> enumValuePrefVar(enumClass: Class<T>, default: T, key: Int)
+            : ReadWriteProperty<KotprefModel, T> = EnumValuePrefVar(enumClass, default, context.getString(key))
+
+    /**
+     * Delegate enum-based shared preference property storing and recalling by the enum value's name as a string.
+     * @param values Enum class to define the property
+     * @param default default enum value
+     * @param key custom preference key
+     */
+    protected fun <T : Enum<*>> enumNullableValuePrefVar(enumClass: Class<T>, default: T? = null, key: String? = null)
+            : ReadWriteProperty<KotprefModel, T?> = EnumNullableValuePrefVar(enumClass, default, key)
+
+    /**
+     * Delegate enum-based shared preference property storing and recalling by the enum value's name as a string.
+     * @param values Enum class to define the property
+     * @param default default enum value
+     * @param key custom preference key resource id
+     */
+    protected fun <T : Enum<*>> enumNullableValuePrefVar(enumClass: Class<T>, default: T, key: Int)
+            : ReadWriteProperty<KotprefModel, T> = EnumValuePrefVar(enumClass, default, context.getString(key))
+
+    /**
+     * Delegate enum-based shared preference property storing and recalling by the enum value's ordinal as an integer.
+     * @param values Enum class to define the property
+     * @param default default enum value
+     * @param key custom preference key
+     */
+    protected fun <T : Enum<*>> enumOrdinalPrefVar(enumClass: Class<T>, default: T, key: String? = null)
+            : ReadWriteProperty<KotprefModel, T> = EnumOrdinalPrefVar(enumClass, default, key)
+
+    /**
+     * Delegate enum-based shared preference property storing and recalling by the enum value's ordinal as an integer.
+     * @param values Enum class to define the property
+     * @param default default enum value
+     * @param key custom preference key resource id
+     */
+    protected fun <T : Enum<*>> enumOrdinalPrefVar(enumClass: Class<T>, default: T, key: Int)
+            : ReadWriteProperty<KotprefModel, T> = EnumOrdinalPrefVar(enumClass, default, context.getString(key))
+
+    /**
      * Delegate string set shared preference property.
      * @param default default string set value
      * @param key custom preference key
@@ -332,6 +386,57 @@ abstract class KotprefModel() {
 
         override fun setToEditor(property: KProperty<*>, value: Boolean, editor: SharedPreferences.Editor) {
             editor.putBoolean(key ?: property.name, value)
+        }
+    }
+
+    private inner class EnumValuePrefVar<T : Enum<*>>(enumClass : Class<T>, val default: T, val key: String?) : PrefVar<T>() {
+        private val enumConstants = enumClass.enumConstants
+
+        override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
+            val value = preference.getString(key ?: property.name, default.name)
+            return enumConstants.first { it.name == value }
+        }
+
+        override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
+            preference.edit().putString(key ?: property.name, value.name).apply()
+        }
+
+        override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
+            editor.putString(key ?: property.name, value.name)
+        }
+    }
+
+    private inner class EnumNullableValuePrefVar<T : Enum<*>>(enumClass : Class<T>, val default: T?, val key: String?) : PrefVar<T?>() {
+        private val enumConstants = enumClass.enumConstants
+
+        override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
+            val value = preference.getString(key ?: property.name, default?.name)
+            return enumConstants.firstOrNull { it.name == value }
+        }
+
+        override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
+            preference.edit().putString(key ?: property.name, value?.name).apply()
+        }
+
+        override fun setToEditor(property: KProperty<*>, value: T?, editor: SharedPreferences.Editor) {
+            editor.putString(key ?: property.name, value?.name)
+        }
+    }
+
+    private inner class EnumOrdinalPrefVar<T : Enum<*>>(enumClass : Class<T>, val default: T, val key: String?) : PrefVar<T>() {
+        private val enumConstants = enumClass.enumConstants
+
+        override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
+            val value = preference.getInt(key ?: property.name, default.ordinal)
+            return enumConstants.first { it.ordinal == value }
+        }
+
+        override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
+            preference.edit().putInt(key ?: property.name, value.ordinal).apply()
+        }
+
+        override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
+            editor.putInt(key ?: property.name, value.ordinal)
         }
     }
 

--- a/kotpref/src/test/java/com/chibatching/kotpref/ExampleEnum.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/ExampleEnum.kt
@@ -1,0 +1,7 @@
+package com.chibatching.kotpref
+
+enum class ExampleEnum {
+    FIRST,
+    SECOND,
+    THIRD
+}

--- a/kotpref/src/test/java/com/chibatching/kotpref/KotprefBasicTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/KotprefBasicTest.kt
@@ -25,6 +25,9 @@ class KotprefBasicTest {
         var testBooleanVar: Boolean by booleanPrefVar()
         var testStringVar: String by stringPrefVar()
         var testStringNullableVar: String? by stringNullablePrefVar()
+        var testEnumValueVar: ExampleEnum by enumValuePrefVar(ExampleEnum::class.java, ExampleEnum.FIRST)
+        var testEnumNullableValueVar: ExampleEnum? by enumNullableValuePrefVar(ExampleEnum::class.java)
+        var testEnumOrdinalVar: ExampleEnum by enumOrdinalPrefVar(ExampleEnum::class.java, ExampleEnum.FIRST)
         val testStringSetVal: MutableSet<String> by stringSetPrefVal(TreeSet<String>())
         val testLazyDefaultSS: MutableSet<String> by stringSetPrefVal {
             val defSet = LinkedHashSet<String>()
@@ -124,6 +127,42 @@ class KotprefBasicTest {
         example.testStringNullableVar = "Ohayo!"
         assertThat(example.testStringNullableVar, equalTo("Ohayo!"))
         assertThat(example.testStringNullableVar, equalTo(pref.getString("testStringNullableVar", "")))
+    }
+
+    @Test
+    fun enumValuePrefVarDefaultSameValueAsDefined() {
+        assertThat(example.testEnumValueVar, equalTo(ExampleEnum.FIRST))
+    }
+
+    @Test
+    fun setEnumValuePrefVarSetSameValueToPreference() {
+        example.testEnumValueVar = ExampleEnum.SECOND
+        assertThat(example.testEnumValueVar, equalTo(ExampleEnum.SECOND))
+        assertThat(example.testEnumValueVar.name, equalTo(pref.getString("testEnumValueVar", "")))
+    }
+
+    @Test
+    fun enumNullableValuePrefVarDefaultIsNull() {
+        assertThat(example.testEnumNullableValueVar, nullValue())
+    }
+
+    @Test
+    fun setEnumNullableValuePrefVarSetSameValueToPreference() {
+        example.testEnumNullableValueVar = ExampleEnum.SECOND
+        assertThat(example.testEnumNullableValueVar, equalTo(ExampleEnum.SECOND))
+        assertThat(example.testEnumNullableValueVar!!.name, equalTo(pref.getString("testEnumNullableValueVar", "")))
+    }
+
+    @Test
+    fun enumOrdinalPrefVarDefaultSameValueAsDefined() {
+        assertThat(example.testEnumOrdinalVar, equalTo(ExampleEnum.FIRST))
+    }
+
+    @Test
+    fun setEnumOrdinalPrefVarSetSameValueToPreference() {
+        example.testEnumOrdinalVar = ExampleEnum.SECOND
+        assertThat(example.testEnumOrdinalVar, equalTo(ExampleEnum.SECOND))
+        assertThat(example.testEnumOrdinalVar.ordinal, equalTo(pref.getInt("testEnumOrdinalVar", 0)))
     }
 
     @Test


### PR DESCRIPTION
Should resolve #18. The option I went with is to provide an enum's possible values as the first argument when defining the preference variable. Another option could be to provide the enum's class itself and then using `enumConstants` to retrieve the list instead. That could be a bit cleaner but may require usage of `kotlin-reflection` which some library users might not find desirable.