### PR TITLE
RemoveJava 8 API call to avoid crash on Android

### DIFF
--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefPreferences.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefPreferences.kt
@@ -4,6 +4,7 @@ import android.annotation.TargetApi
 import android.content.SharedPreferences
 import android.os.Build
 import com.chibatching.kotpref.pref.StringSetPref
+import java.util.*
 
 
 internal class KotprefPreferences(val preferences: SharedPreferences) : SharedPreferences by preferences {
@@ -14,13 +15,15 @@ internal class KotprefPreferences(val preferences: SharedPreferences) : SharedPr
 
     internal inner class KotprefEditor(val editor: SharedPreferences.Editor) : SharedPreferences.Editor by editor {
 
-        private val prefStringSet: HashMap<String, StringSetPref.PrefMutableSet> by lazy { HashMap<String, StringSetPref.PrefMutableSet>() }
+        private val prefStringSet: MutableMap<String, StringSetPref.PrefMutableSet> by lazy { HashMap<String, StringSetPref.PrefMutableSet>() }
 
         override fun apply() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                prefStringSet.forEach { key, set ->
-                    editor.putStringSet(key, set)
-                    set.syncTransaction()
+                prefStringSet.keys.forEach { key ->
+                    prefStringSet[key]?.let {
+                        editor.putStringSet(key, it)
+                        it.syncTransaction()
+                    }
                 }
                 prefStringSet.clear()
             }


### PR DESCRIPTION
## Issue

- java.lang.NoClassDefFoundError: com.chibatching.kotpref.KotprefPreferences$KotprefEditor$apply$1 #43

## Cause

- Calling Java 8 API `Map#forEach` on Android
  - ref: http://blog.danlew.net/2017/03/16/kotlin-puzzler-whose-line-is-it-anyways/

## Do

Remove calling Java 8 API, use `Map.keys.forEach`