### PR TITLE
support for commitByDefault

### DIFF
--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
@@ -1,12 +1,14 @@
 package com.chibatching.kotpref.enumpref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class EnumNullableValuePref<T : Enum<*>>(enumClass : KClass<T>, val default: T?, val key: String?) : AbstractPref<T?>() {
+class EnumNullableValuePref<T : Enum<*>>(enumClass: KClass<T>, val default: T?, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T?>() {
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
@@ -14,8 +16,9 @@ class EnumNullableValuePref<T : Enum<*>>(enumClass : KClass<T>, val default: T?,
         return enumConstants.firstOrNull { it.name == value }
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value?.name).apply()
+        preference.edit().putString(key ?: property.name, value?.name).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: T?, editor: SharedPreferences.Editor) {

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
@@ -1,12 +1,14 @@
 package com.chibatching.kotpref.enumpref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class EnumOrdinalPref<T : Enum<*>>(enumClass : KClass<T>, val default: T, val key: String?) : AbstractPref<T>() {
+class EnumOrdinalPref<T : Enum<*>>(enumClass: KClass<T>, val default: T, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
@@ -14,8 +16,9 @@ class EnumOrdinalPref<T : Enum<*>>(enumClass : KClass<T>, val default: T, val ke
         return enumConstants.first { it.ordinal == value }
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
-        preference.edit().putInt(key ?: property.name, value.ordinal).apply()
+        preference.edit().putInt(key ?: property.name, value.ordinal).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumPropertyExtensions.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumPropertyExtensions.kt
@@ -9,45 +9,45 @@ import kotlin.properties.ReadWriteProperty
  * @param default default enum value
  * @param key custom preferences key
  */
-inline fun <reified T : Enum<*>> KotprefModel.enumValuePref(default: T, key: String? = null)
-        : ReadWriteProperty<KotprefModel, T> = EnumValuePref(T::class, default, key)
+inline fun <reified T : Enum<*>> KotprefModel.enumValuePref(default: T, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T> = EnumValuePref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's name as a string.
  * @param default default enum value
  * @param key custom preferences key resource id
  */
-inline fun <reified T : Enum<*>> KotprefModel.enumValuePref(default: T, key: Int)
-        : ReadWriteProperty<KotprefModel, T> = EnumValuePref(T::class, default, context.getString(key))
+inline fun <reified T : Enum<*>> KotprefModel.enumValuePref(default: T, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T> = EnumValuePref(T::class, default, context.getString(key), commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's name as a string.
  * @param default default enum value
  * @param key custom preferences key
  */
-inline fun <reified T : Enum<*>> KotprefModel.nullableEnumValuePref(default: T? = null, key: String? = null)
-        : ReadWriteProperty<KotprefModel, T?> = EnumNullableValuePref(T::class, default, key)
+inline fun <reified T : Enum<*>> KotprefModel.nullableEnumValuePref(default: T? = null, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T?> = EnumNullableValuePref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's name as a string.
  * @param default default enum value
  * @param key custom preferences key resource id
  */
-inline fun <reified T : Enum<*>> KotprefModel.enumNullableValuePref(default: T? = null, key: Int)
-        : ReadWriteProperty<KotprefModel, T?> = EnumNullableValuePref(T::class, default, context.getString(key))
+inline fun <reified T : Enum<*>> KotprefModel.enumNullableValuePref(default: T? = null, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T?> = EnumNullableValuePref(T::class, default, context.getString(key), commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's ordinal as an integer.
  * @param default default enum value
  * @param key custom preferences key
  */
-inline fun <reified T : Enum<*>> KotprefModel.enumOrdinalPref(default: T, key: String? = null)
-        : ReadWriteProperty<KotprefModel, T> = EnumOrdinalPref(T::class, default, key)
+inline fun <reified T : Enum<*>> KotprefModel.enumOrdinalPref(default: T, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T> = EnumOrdinalPref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's ordinal as an integer.
  * @param default default enum value
  * @param key custom preferences key resource id
  */
-inline fun <reified T : Enum<*>> KotprefModel.enumOrdinalPref(default: T, key: Int)
-        : ReadWriteProperty<KotprefModel, T> = EnumOrdinalPref(T::class, default, context.getString(key))
+inline fun <reified T : Enum<*>> KotprefModel.enumOrdinalPref(default: T, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T> = EnumOrdinalPref(T::class, default, context.getString(key), commitByDefault)

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
@@ -1,12 +1,14 @@
 package com.chibatching.kotpref.enumpref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class EnumValuePref<T : Enum<*>>(enumClass : KClass<T>, val default: T, val key: String?) : AbstractPref<T>() {
+class EnumValuePref<T : Enum<*>>(enumClass: KClass<T>, val default: T, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
@@ -14,8 +16,9 @@ class EnumValuePref<T : Enum<*>>(enumClass : KClass<T>, val default: T, val key:
         return enumConstants.first { it.name == value }
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value.name).apply()
+        preference.edit().putString(key ?: property.name, value.name).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {

--- a/enum-support/src/test/java/com/chibatching/kotpref/enumpref/EnumSupportTest.kt
+++ b/enum-support/src/test/java/com/chibatching/kotpref/enumpref/EnumSupportTest.kt
@@ -9,14 +9,26 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class EnumSupportTest {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class EnumSupportTest(private val commitAllProperties: Boolean) {
 
-    class Example : KotprefModel() {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
+
+    class Example(private val commitAllProperties: Boolean) : KotprefModel() {
+        override val commitAllPropertiesByDefault: Boolean
+            get() = commitAllProperties
+
         var testEnumValue by enumValuePref(ExampleEnum.FIRST)
         var testEnumNullableValue: ExampleEnum? by nullableEnumValuePref()
         var testEnumOrdinal by enumOrdinalPref(ExampleEnum.FIRST)
@@ -30,7 +42,7 @@ class EnumSupportTest {
     fun setUp() {
         context = RuntimeEnvironment.application
         Kotpref.init(context)
-        example = Example()
+        example = Example(commitAllProperties)
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
@@ -1,13 +1,15 @@
 package com.chibatching.kotpref.gsonpref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.Kotpref
+import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class GsonNullablePref<T : Any>(val targetClass: KClass<T>, val default: T?, val key: String?) : AbstractPref<T?>() {
+class GsonNullablePref<T : Any>(val targetClass: KClass<T>, val default: T?, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T?>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
         return preference.getString(key ?: property.name, null)?.let { json ->
@@ -15,9 +17,10 @@ class GsonNullablePref<T : Any>(val targetClass: KClass<T>, val default: T?, val
         }
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
         serializeToJson(value).let { json ->
-            preference.edit().putString(key ?: property.name, json).apply()
+            preference.edit().putString(key ?: property.name, json).execute(commitByDefault)
         }
     }
 

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
@@ -1,13 +1,15 @@
 package com.chibatching.kotpref.gsonpref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.Kotpref
+import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class GsonPref<T : Any>(val targetClass: KClass<T>, val default: T, val key: String?) : AbstractPref<T>() {
+class GsonPref<T : Any>(val targetClass: KClass<T>, val default: T, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
         return preference.getString(key ?: property.name, null)?.let { json ->
@@ -15,9 +17,10 @@ class GsonPref<T : Any>(val targetClass: KClass<T>, val default: T, val key: Str
         } ?: default
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
         serializeToJson(value).let { json ->
-            preference.edit().putString(key ?: property.name, json).apply()
+            preference.edit().putString(key ?: property.name, json).execute(commitByDefault)
         }
     }
 

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/KotprefGsonExtentions.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/KotprefGsonExtentions.kt
@@ -22,29 +22,29 @@ var Kotpref.gson: Gson?
  * @param default default gson object value
  * @param key custom preferences key
  */
-inline fun <reified T : Any> KotprefModel.gsonPref(default: T, key: String? = null)
-        : ReadWriteProperty<KotprefModel, T> = GsonPref(T::class, default, key)
+inline fun <reified T : Any> KotprefModel.gsonPref(default: T, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T> = GsonPref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate shared preferences property serialized and deserialized by gson
  * @param default default gson object value
  * @param key custom preferences key resource id
  */
-inline fun <reified T : Any> KotprefModel.gsonPref(default: T, key: Int)
-        : ReadWriteProperty<KotprefModel, T> = GsonPref(T::class, default, context.getString(key))
+inline fun <reified T : Any> KotprefModel.gsonPref(default: T, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T> = GsonPref(T::class, default, context.getString(key), commitByDefault)
 
 /**
  * Delegate shared preferences property serialized and deserialized by gson
  * @param default default gson object value
  * @param key custom preferences key
  */
-inline fun <reified T : Any> KotprefModel.gsonNullablePref(default: T? = null, key: String? = null)
-        : ReadWriteProperty<KotprefModel, T?> = GsonNullablePref(T::class, default, key)
+inline fun <reified T : Any> KotprefModel.gsonNullablePref(default: T? = null, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T?> = GsonNullablePref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate shared preferences property serialized and deserialized by gson
  * @param default default gson object value
  * @param key custom preferences key resource id
  */
-inline fun <reified T : Any> KotprefModel.gsonNullablePref(default: T? = null, key: Int)
-        : ReadWriteProperty<KotprefModel, T?> = GsonNullablePref(T::class, default, context.getString(key))
+inline fun <reified T : Any> KotprefModel.gsonNullablePref(default: T? = null, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+        : ReadWriteProperty<KotprefModel, T?> = GsonNullablePref(T::class, default, context.getString(key), commitByDefault)

--- a/gson-support/src/test/java/com/chibatching/kotpref/gsonpref/GsonSupportTest.kt
+++ b/gson-support/src/test/java/com/chibatching/kotpref/gsonpref/GsonSupportTest.kt
@@ -10,15 +10,21 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class GsonSupportTest {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class GsonSupportTest(private val commitAllProperties: Boolean) {
 
     companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+
         fun createDefaultContent(): Content
                 = Content("default title", "contents write here", createDate(2017, 1, 5))
 
@@ -32,7 +38,10 @@ class GsonSupportTest {
                 }.time
     }
 
-    class Example : KotprefModel() {
+    class Example(private val commitAllProperties: Boolean) : KotprefModel() {
+        override val commitAllPropertiesByDefault: Boolean
+            get() = commitAllProperties
+
         var content by gsonPref(createDefaultContent())
 
         var nullableContent: Content? by gsonNullablePref()
@@ -47,7 +56,7 @@ class GsonSupportTest {
         context = RuntimeEnvironment.application
         Kotpref.init(context)
         Kotpref.gson = Gson()
-        example = Example()
+        example = Example(commitAllProperties)
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.content.SharedPreferences
@@ -24,6 +25,11 @@ abstract class KotprefModel {
      * Preference file name
      */
     protected open val kotprefName: String = javaClass.simpleName
+
+    /**
+     * commit() all properties in this pref by default instead of apply()
+     */
+    open val commitAllPropertiesByDefault: Boolean = false
 
     /**
      * Preference read/write mode
@@ -63,137 +69,154 @@ abstract class KotprefModel {
      * Delegate string shared preferences property.
      * @param default default string value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun stringPref(default: String = "", key: String? = null)
-            : ReadWriteProperty<KotprefModel, String> = StringPref(default, key)
+    protected fun stringPref(default: String = "", key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, String> = StringPref(default, key, commitByDefault)
 
     /**
      * Delegate string shared preferences property.
      * @param default default string value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun stringPref(default: String = "", key: Int)
-            : ReadWriteProperty<KotprefModel, String> = stringPref(default, context.getString(key))
+    protected fun stringPref(default: String = "", key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, String> = stringPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate nullable string shared preferences property.
      * @param default default string value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun nullableStringPref(default: String? = null, key: String? = null)
-            : ReadWriteProperty<KotprefModel, String?> = StringNullablePref(default, key)
+    protected fun nullableStringPref(default: String? = null, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, String?> = StringNullablePref(default, key, commitByDefault)
 
     /**
      * Delegate nullable string shared preferences property.
      * @param default default string value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun nullableStringPref(default: String? = null, key: Int)
-            : ReadWriteProperty<KotprefModel, String?> = nullableStringPref(default, context.getString(key))
+    protected fun nullableStringPref(default: String? = null, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, String?> = nullableStringPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate int shared preferences property.
      * @param default default int value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun intPref(default: Int = 0, key: String? = null)
-            : ReadWriteProperty<KotprefModel, Int> = IntPref(default, key)
+    protected fun intPref(default: Int = 0, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Int> = IntPref(default, key, commitByDefault)
 
     /**
      * Delegate int shared preferences property.
      * @param default default int value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun intPref(default: Int = 0, key: Int)
-            : ReadWriteProperty<KotprefModel, Int> = intPref(default, context.getString(key))
+    protected fun intPref(default: Int = 0, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Int> = intPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate long shared preferences property.
      * @param default default long value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun longPref(default: Long = 0L, key: String? = null)
-            : ReadWriteProperty<KotprefModel, Long> = LongPref(default, key)
+    protected fun longPref(default: Long = 0L, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Long> = LongPref(default, key, commitByDefault)
 
     /**
      * Delegate long shared preferences property.
      * @param default default long value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun longPref(default: Long = 0L, key: Int)
-            : ReadWriteProperty<KotprefModel, Long> = longPref(default, context.getString(key))
+    protected fun longPref(default: Long = 0L, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Long> = longPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate float shared preferences property.
      * @param default default float value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun floatPref(default: Float = 0F, key: String? = null)
-            : ReadWriteProperty<KotprefModel, Float> = FloatPref(default, key)
+    protected fun floatPref(default: Float = 0F, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Float> = FloatPref(default, key, commitByDefault)
 
     /**
      * Delegate float shared preferences property.
      * @param default default float value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun floatPref(default: Float = 0F, key: Int)
-            : ReadWriteProperty<KotprefModel, Float> = floatPref(default, context.getString(key))
+    protected fun floatPref(default: Float = 0F, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Float> = floatPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate boolean shared preferences property.
      * @param default default boolean value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun booleanPref(default: Boolean = false, key: String? = null)
-            : ReadWriteProperty<KotprefModel, Boolean> = BooleanPref(default, key)
+    protected fun booleanPref(default: Boolean = false, key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Boolean> = BooleanPref(default, key, commitByDefault)
 
     /**
      * Delegate boolean shared preferences property.
      * @param default default boolean value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
-    protected fun booleanPref(default: Boolean = false, key: Int)
-            : ReadWriteProperty<KotprefModel, Boolean> = booleanPref(default, context.getString(key))
+    protected fun booleanPref(default: Boolean = false, key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadWriteProperty<KotprefModel, Boolean> = booleanPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate string set shared preferences property.
      * @param default default string set value
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    protected fun stringSetPref(default: Set<String> = LinkedHashSet<String>(), key: String? = null)
-            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = stringSetPref(key) { default }
+    protected fun stringSetPref(default: Set<String> = LinkedHashSet<String>(), key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = stringSetPref(key, commitByDefault) { default }
 
     /**
      * Delegate string set shared preferences property.
      * @param default default string set value
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    protected fun stringSetPref(default: Set<String> = LinkedHashSet<String>(), key: Int)
-            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = stringSetPref(context.getString(key)) { default }
+    protected fun stringSetPref(default: Set<String> = LinkedHashSet<String>(), key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault)
+            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = stringSetPref(context.getString(key), commitByDefault) { default }
 
     /**
      * Delegate string set shared preferences property.
      * @param key custom preferences key
+     * @param commitByDefault commit this property instead of apply
      * @param default default string set value creation function
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    protected fun stringSetPref(key: String? = null, default: () -> Set<String>)
-            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = StringSetPref(default, key)
+    protected fun stringSetPref(key: String? = null, commitByDefault: Boolean = commitAllPropertiesByDefault, default: () -> Set<String>)
+            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = StringSetPref(default, key, commitByDefault)
 
     /**
      * Delegate string set shared preferences property.
      * @param key custom preferences key resource id
+     * @param commitByDefault commit this property instead of apply
      * @param default default string set value
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    protected fun stringSetPref(key: Int, default: () -> Set<String>)
-            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = stringSetPref(context.getString(key), default)
+    protected fun stringSetPref(key: Int, commitByDefault: Boolean = commitAllPropertiesByDefault, default: () -> Set<String>)
+            : ReadOnlyProperty<KotprefModel, MutableSet<String>> = stringSetPref(context.getString(key), commitByDefault, default)
 
     /**
      * Begin bulk edit mode. You must commit or cancel after bulk edit finished.
      */
+    @SuppressLint("CommitPrefEdits")
     fun beginBulkEdit() {
         kotprefInTransaction = true
         kotprefTransactionStartTime = System.currentTimeMillis()

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/SharedPrefExtensions.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/SharedPrefExtensions.kt
@@ -1,0 +1,15 @@
+package com.chibatching.kotpref
+
+import android.content.SharedPreferences
+
+
+/**
+ * Extension to choose between {@link SharedPreferences.Editor.commit} and {@link SharedPreferences.Editor.apply}
+ * @param synchronous save to sharedPref file instantly
+ */
+fun SharedPreferences.Editor.execute(synchronous: Boolean) {
+    if (synchronous)
+        commit()
+    else
+        apply()
+}

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/SharedPrefExtensions.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/SharedPrefExtensions.kt
@@ -8,8 +8,5 @@ import android.content.SharedPreferences
  * @param synchronous save to sharedPref file instantly
  */
 fun SharedPreferences.Editor.execute(synchronous: Boolean) {
-    if (synchronous)
-        commit()
-    else
-        apply()
+    if (synchronous) commit() else apply()
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
@@ -1,17 +1,20 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class BooleanPref(val default: Boolean, val key: String?) : AbstractPref<Boolean>() {
+internal class BooleanPref(val default: Boolean, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Boolean>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Boolean {
         return preference.getBoolean(key ?: property.name, default)
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: Boolean, preference: SharedPreferences) {
-        preference.edit().putBoolean(key ?: property.name, value).apply()
+        preference.edit().putBoolean(key ?: property.name, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: Boolean, editor: SharedPreferences.Editor) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
@@ -1,17 +1,20 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class FloatPref(val default: Float, val key: String?) : AbstractPref<Float>() {
+internal class FloatPref(val default: Float, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Float>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Float {
         return preference.getFloat(key ?: property.name, default)
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: Float, preference: SharedPreferences) {
-        preference.edit().putFloat(key ?: property.name, value).apply()
+        preference.edit().putFloat(key ?: property.name, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: Float, editor: SharedPreferences.Editor) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
@@ -1,17 +1,20 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class IntPref(val default: Int, val key: String?) : AbstractPref<Int>() {
+internal class IntPref(val default: Int, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Int>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Int {
         return preference.getInt(key ?: property.name, default)
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: Int, preference: SharedPreferences) {
-        preference.edit().putInt(key ?: property.name, value).apply()
+        preference.edit().putInt(key ?: property.name, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: Int, editor: SharedPreferences.Editor) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
@@ -1,17 +1,20 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class LongPref(val default: Long, val key: String?) : AbstractPref<Long>() {
+internal class LongPref(val default: Long, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Long>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Long {
         return preference.getLong(key ?: property.name, default)
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: Long, preference: SharedPreferences) {
-        preference.edit().putLong(key ?: property.name, value).apply()
+        preference.edit().putLong(key ?: property.name, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: Long, editor: SharedPreferences.Editor) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
@@ -1,17 +1,20 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class StringNullablePref(val default: String?, val key: String?) : AbstractPref<String?>() {
+internal class StringNullablePref(val default: String?, val key: String?, private val commitByDefault: Boolean) : AbstractPref<String?>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String? {
         return preference.getString(key ?: property.name, default)
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: String?, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value).apply()
+        preference.edit().putString(key ?: property.name, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: String?, editor: SharedPreferences.Editor) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
@@ -1,17 +1,20 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class StringPref(val default: String, val key: String?) : AbstractPref<String>() {
+internal class StringPref(val default: String, val key: String?, private val commitByDefault: Boolean) : AbstractPref<String>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String {
         return preference.getString(key ?: property.name, default)
     }
 
+    @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: String, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value).apply()
+        preference.edit().putString(key ?: property.name, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: String, editor: SharedPreferences.Editor) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
@@ -1,13 +1,15 @@
 package com.chibatching.kotpref.pref
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.os.Build
 import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.execute
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-internal class StringSetPref(val default: () -> Set<String>, val key: String?) : ReadOnlyProperty<KotprefModel, MutableSet<String>> {
+internal class StringSetPref(val default: () -> Set<String>, val key: String?, private val commitByDefault: Boolean) : ReadOnlyProperty<KotprefModel, MutableSet<String>> {
 
     private var stringSet: MutableSet<String>? = null
     private var lastUpdate: Long = 0L
@@ -37,12 +39,13 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
             synchronized(this) {
                 transactionData?.let {
                     set.clear()
-                    set.addAll(transactionData!!)
+                    set.addAll(it)
                     transactionData = null
                 }
             }
         }
 
+        @SuppressLint("CommitPrefEdits")
         override fun add(element: String): Boolean {
             if (kotprefModel.kotprefInTransaction) {
                 val result = transactionData!!.add(element)
@@ -50,10 +53,11 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
                 return result
             }
             val result = set.add(element)
-            kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+            kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
             return result
         }
 
+        @SuppressLint("CommitPrefEdits")
         override fun addAll(elements: Collection<String>): Boolean {
             if (kotprefModel.kotprefInTransaction) {
                 val result = transactionData!!.addAll(elements)
@@ -61,10 +65,11 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
                 return result
             }
             val result = set.addAll(elements)
-            kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+            kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
             return result
         }
 
+        @SuppressLint("CommitPrefEdits")
         override fun remove(element: String): Boolean {
             if (kotprefModel.kotprefInTransaction) {
                 val result = transactionData!!.remove(element)
@@ -72,10 +77,11 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
                 return result
             }
             val result = set.remove(element)
-            kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+            kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
             return result
         }
 
+        @SuppressLint("CommitPrefEdits")
         override fun removeAll(elements: Collection<String>): Boolean {
             if (kotprefModel.kotprefInTransaction) {
                 val result = transactionData!!.removeAll(elements)
@@ -83,10 +89,11 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
                 return result
             }
             val result = set.removeAll(elements)
-            kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+            kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
             return result
         }
 
+        @SuppressLint("CommitPrefEdits")
         override fun retainAll(elements: Collection<String>): Boolean {
             if (kotprefModel.kotprefInTransaction) {
                 val result = transactionData!!.retainAll(elements)
@@ -94,10 +101,11 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
                 return result
             }
             val result = set.retainAll(elements)
-            kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+            kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
             return result
         }
 
+        @SuppressLint("CommitPrefEdits")
         override fun clear() {
             if (kotprefModel.kotprefInTransaction) {
                 val result = transactionData!!.clear()
@@ -105,7 +113,7 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
                 return result
             }
             set.clear()
-            kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+            kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
         }
 
         override fun contains(element: String): Boolean {
@@ -142,10 +150,11 @@ internal class StringSetPref(val default: () -> Set<String>, val key: String?) :
         private inner class KotprefMutableIterator(
                 val baseIterator: MutableIterator<String>, val inTransaction: Boolean) : MutableIterator<String> by baseIterator {
 
+            @SuppressLint("CommitPrefEdits")
             override fun remove() {
                 baseIterator.remove()
                 if (!inTransaction) {
-                    kotprefModel.kotprefPreference.edit().putStringSet(key, set).apply()
+                    kotprefModel.kotprefPreference.edit().putStringSet(key, set).execute(commitByDefault)
                 }
             }
         }

--- a/kotpref/src/test/java/com/chibatching/kotpref/BlockingBulkEditTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/BlockingBulkEditTest.kt
@@ -10,14 +10,21 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import java.util.*
 import kotlin.collections.HashSet
 
 
-@RunWith(RobolectricTestRunner::class)
-class BlockingBulkEditTest {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     lateinit var example: Example
     lateinit var context: Context
@@ -27,7 +34,7 @@ class BlockingBulkEditTest {
     fun setUp() {
         context = RuntimeEnvironment.application
         Kotpref.init(context)
-        example = Example()
+        example = Example(commitAllProperties)
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/kotpref/src/test/java/com/chibatching/kotpref/BulkEditTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/BulkEditTest.kt
@@ -9,13 +9,20 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class BulkEditTest {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class BulkEditTest(private val commitAllProperties: Boolean) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     lateinit var example: Example
     lateinit var context: Context
@@ -25,7 +32,7 @@ class BulkEditTest {
     fun setUp() {
         context = RuntimeEnvironment.application
         Kotpref.init(context)
-        example = Example()
+        example = Example(commitAllProperties)
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/kotpref/src/test/java/com/chibatching/kotpref/CustomExample.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/CustomExample.kt
@@ -3,7 +3,9 @@ package com.chibatching.kotpref
 import java.util.*
 
 
-class CustomExample : KotprefModel() {
+class CustomExample(private val commitAllProperties: Boolean) : KotprefModel() {
+    override val commitAllPropertiesByDefault: Boolean
+        get() = commitAllProperties
 
     companion object {
         val PREFERENCE_NAME = "custom_example"

--- a/kotpref/src/test/java/com/chibatching/kotpref/Example.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/Example.kt
@@ -3,7 +3,10 @@ package com.chibatching.kotpref
 import java.util.*
 
 
-class Example : KotprefModel() {
+class Example(private val commitAllProperties: Boolean) : KotprefModel() {
+    override val commitAllPropertiesByDefault: Boolean
+        get() = commitAllProperties
+
     var testInt by intPref()
     var testLong by longPref()
     var testFloat by floatPref()

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/BasePrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/BasePrefTest.kt
@@ -10,7 +10,7 @@ import org.junit.Before
 import org.robolectric.RuntimeEnvironment
 
 
-abstract class BasePrefTest {
+abstract class BasePrefTest(private val commitAllProperties: Boolean) {
 
     lateinit var example: Example
     lateinit var customExample: CustomExample
@@ -22,8 +22,8 @@ abstract class BasePrefTest {
     fun setUp() {
         context = RuntimeEnvironment.application
         Kotpref.init(context)
-        example = Example()
-        customExample = CustomExample()
+        example = Example(commitAllProperties)
+        customExample = CustomExample(commitAllProperties)
 
         examplePref = example.preferences
         examplePref.edit().clear().commit()

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/BooleanPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/BooleanPrefTest.kt
@@ -4,11 +4,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class BooleanPrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class BooleanPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
 
     @Test

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/FloatPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/FloatPrefTest.kt
@@ -4,11 +4,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class FloatPrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class FloatPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     @Test
     fun floatPrefDefaultIs0() {

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/IntPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/IntPrefTest.kt
@@ -4,11 +4,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class IntPrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class IntPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     @Test
     fun intPrefDefaultIs0() {

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/LongPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/LongPrefTest.kt
@@ -4,11 +4,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class LongPrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class LongPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     @Test
     fun longPrefDefaultIs0() {

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/StringNullablePrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/StringNullablePrefTest.kt
@@ -4,11 +4,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class StringNullablePrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class StringNullablePrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     @Test
     fun stringPrefDefaultIsNull() {

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/StringPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/StringPrefTest.kt
@@ -4,11 +4,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class StringPrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class StringPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     @Test
     fun stringPrefDefaultIsEmptyString() {

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/StringSetPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/StringSetPrefTest.kt
@@ -6,12 +6,19 @@ import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
 import java.util.*
 
 
-@RunWith(RobolectricTestRunner::class)
-class StringSetPrefTest : BasePrefTest() {
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class StringSetPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperties) {
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "commitAllProperties = {0}")
+        fun data(): Collection<Array<out Any>> {
+            return Arrays.asList(arrayOf(false), arrayOf(true))
+        }
+    }
 
     @Test
     fun stringSetPrefDefaultSizeIs0() {


### PR DESCRIPTION
Thankyou for such a wonderful library. Using it in many of my projects.

in many cases app might need **commit** for some properties. 
> commit/apply doesn't much depend on scenario, those rather depend on property.
> we can use blockingCommit but adding blockingCommit every time we access that property is difficult.

**Changes**
1. added support for commitByDefault
2. added Parameterized unit tests for commitByDefault feature
3. no breaking changes
  