### PR TITLE
Handle custom preference key properly

### DIFF
--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class EnumNullableValuePref<T : Enum<*>>(enumClass: KClass<T>, val default: T?, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T?>() {
+class EnumNullableValuePref<T : Enum<*>>(enumClass: KClass<T>, val default: T?, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<T?>() {
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class EnumOrdinalPref<T : Enum<*>>(enumClass: KClass<T>, val default: T, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
+class EnumOrdinalPref<T : Enum<*>>(enumClass: KClass<T>, val default: T, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class EnumValuePref<T : Enum<*>>(enumClass: KClass<T>, val default: T, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
+class EnumValuePref<T : Enum<*>>(enumClass: KClass<T>, val default: T, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class GsonNullablePref<T : Any>(val targetClass: KClass<T>, val default: T?, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T?>() {
+class GsonNullablePref<T : Any>(val targetClass: KClass<T>, val default: T?, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<T?>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
         return preference.getString(key ?: property.name, null)?.let { json ->

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 
-class GsonPref<T : Any>(val targetClass: KClass<T>, val default: T, val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
+class GsonPref<T : Any>(val targetClass: KClass<T>, val default: T, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<T>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
         return preference.getString(key ?: property.name, null)?.let { json ->

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/AbstractPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/AbstractPref.kt
@@ -6,12 +6,14 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 
-abstract class AbstractPref<T : Any?> : ReadWriteProperty<KotprefModel, T> {
+abstract class AbstractPref<T : Any?> : ReadWriteProperty<KotprefModel, T>, PreferenceKey {
 
     private var lastUpdate: Long = 0
     private var transactionData: Any? = null
 
-    operator override fun getValue(thisRef: KotprefModel, property: KProperty<*>): T {
+    abstract override val key: String?
+
+    override operator fun getValue(thisRef: KotprefModel, property: KProperty<*>): T {
         if (!thisRef.kotprefInTransaction) {
             return getFromPreference(property, thisRef.kotprefPreference)
         }
@@ -23,7 +25,7 @@ abstract class AbstractPref<T : Any?> : ReadWriteProperty<KotprefModel, T> {
         return transactionData as T
     }
 
-    operator override fun setValue(thisRef: KotprefModel, property: KProperty<*>, value: T) {
+    override operator fun setValue(thisRef: KotprefModel, property: KProperty<*>, value: T) {
         if (thisRef.kotprefInTransaction) {
             transactionData = value
             lastUpdate = System.currentTimeMillis()

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
@@ -6,7 +6,7 @@ import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class BooleanPref(val default: Boolean, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Boolean>() {
+internal class BooleanPref(val default: Boolean, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<Boolean>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Boolean {
         return preference.getBoolean(key ?: property.name, default)

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
@@ -6,7 +6,7 @@ import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class FloatPref(val default: Float, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Float>() {
+internal class FloatPref(val default: Float, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<Float>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Float {
         return preference.getFloat(key ?: property.name, default)

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
@@ -6,7 +6,7 @@ import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class IntPref(val default: Int, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Int>() {
+internal class IntPref(val default: Int, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<Int>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Int {
         return preference.getInt(key ?: property.name, default)

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
@@ -6,7 +6,7 @@ import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class LongPref(val default: Long, val key: String?, private val commitByDefault: Boolean) : AbstractPref<Long>() {
+internal class LongPref(val default: Long, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<Long>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Long {
         return preference.getLong(key ?: property.name, default)

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/PreferenceKey.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/PreferenceKey.kt
@@ -1,0 +1,6 @@
+package com.chibatching.kotpref.pref
+
+
+interface PreferenceKey {
+    val key: String?
+}

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
@@ -6,7 +6,7 @@ import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class StringNullablePref(val default: String?, val key: String?, private val commitByDefault: Boolean) : AbstractPref<String?>() {
+internal class StringNullablePref(val default: String?, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<String?>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String? {
         return preference.getString(key ?: property.name, default)

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
@@ -6,7 +6,7 @@ import com.chibatching.kotpref.execute
 import kotlin.reflect.KProperty
 
 
-internal class StringPref(val default: String, val key: String?, private val commitByDefault: Boolean) : AbstractPref<String>() {
+internal class StringPref(val default: String, override val key: String?, private val commitByDefault: Boolean) : AbstractPref<String>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String {
         return preference.getString(key ?: property.name, default)

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
@@ -9,12 +9,12 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-internal class StringSetPref(val default: () -> Set<String>, val key: String?, private val commitByDefault: Boolean) : ReadOnlyProperty<KotprefModel, MutableSet<String>> {
+internal class StringSetPref(val default: () -> Set<String>, override val key: String?, private val commitByDefault: Boolean) : ReadOnlyProperty<KotprefModel, MutableSet<String>>, PreferenceKey {
 
     private var stringSet: MutableSet<String>? = null
     private var lastUpdate: Long = 0L
 
-    operator override fun getValue(thisRef: KotprefModel, property: KProperty<*>): MutableSet<String> {
+    override operator fun getValue(thisRef: KotprefModel, property: KProperty<*>): MutableSet<String> {
         if (stringSet == null || lastUpdate < thisRef.kotprefTransactionStartTime) {
             val prefSet = thisRef.kotprefPreference.getStringSet(key ?: property.name, null)
             stringSet = PrefMutableSet(thisRef, prefSet ?: default.invoke().toMutableSet(), key ?: property.name)

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     api project(":kotpref")
 
     api "android.arch.lifecycle:livedata:1.1.0"
+    api "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/livedata-support/src/main/kotlin/com/chibatching/kotpref/livedata/KotprefLiveDataExtensions.kt
+++ b/livedata-support/src/main/kotlin/com/chibatching/kotpref/livedata/KotprefLiveDataExtensions.kt
@@ -3,16 +3,23 @@ package com.chibatching.kotpref.livedata
 import android.arch.lifecycle.LiveData
 import android.content.SharedPreferences
 import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.pref.PreferenceKey
 import kotlin.reflect.KProperty0
+import kotlin.reflect.jvm.isAccessible
 
 fun <T> KotprefModel.asLiveData(property: KProperty0<T>): LiveData<T> {
     return object : LiveData<T>(), SharedPreferences.OnSharedPreferenceChangeListener {
+        private val key: String
+
         init {
             value = property.get()
+            property.isAccessible = true
+            key = (property.getDelegate() as? PreferenceKey)?.key ?: property.name
+            property.isAccessible = false
         }
 
         override fun onSharedPreferenceChanged(prefs: SharedPreferences, propertyName: String) {
-            if (propertyName == property.name) {
+            if (propertyName == key) {
                 postValue(property.get())
             }
         }


### PR DESCRIPTION
New LiveData support module (from #81) can't handle custom preference key properly. Because it uses property name.
This PR is introduce kotlin-reflect library and getting preference key from delegates.