### PR TITLE
Change dependency type from api to compileOnly

### DIFF
--- a/enum-support/build.gradle
+++ b/enum-support/build.gradle
@@ -37,9 +37,10 @@ android {
 }
 
 dependencies {
-    api Deps.Kotlin.stdlib
+    compileOnly Deps.Kotlin.stdlib
     api project(":kotpref")
 
+    testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     testImplementation Deps.assertj

--- a/gson-support/build.gradle
+++ b/gson-support/build.gradle
@@ -37,11 +37,13 @@ android {
 }
 
 dependencies {
-    api Deps.Kotlin.stdlib
+    compileOnly Deps.Kotlin.stdlib
     api project(":kotpref")
 
-    api Deps.gson
+    compileOnly Deps.gson
 
+    testImplementation Deps.Kotlin.stdlib
+    testImplementation Deps.gson
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     testImplementation Deps.assertj

--- a/initializer/build.gradle
+++ b/initializer/build.gradle
@@ -31,8 +31,9 @@ android {
 
 dependencies {
     compileOnly Deps.Kotlin.stdlib
-    compileOnly project(":kotpref")
+    api project(":kotpref")
 
+    testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.junit
     testImplementation Deps.robolectric
 }

--- a/kotpref/build.gradle
+++ b/kotpref/build.gradle
@@ -40,8 +40,9 @@ android {
 }
 
 dependencies {
-    api Deps.Kotlin.stdlib
+    compileOnly Deps.Kotlin.stdlib
 
+    testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     testImplementation Deps.assertj

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -37,12 +37,15 @@ android {
 }
 
 dependencies {
-    api Deps.Kotlin.stdlib
+    compileOnly Deps.Kotlin.stdlib
     api project(":kotpref")
 
-    api Deps.Arch.liveData
-    api Deps.Kotlin.reflect
+    compileOnly Deps.Arch.liveData
+    compileOnly Deps.Kotlin.reflect
 
+    testImplementation Deps.Kotlin.stdlib
+    testImplementation Deps.Kotlin.reflect
+    testImplementation Deps.Arch.liveData
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     testImplementation Deps.assertj

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-    android {
+android {
     compileSdkVersion Versions.targetSdk
     buildToolsVersion Versions.buildTools
 
@@ -37,10 +37,23 @@ dependencies {
     implementation Deps.SupportLibrary.appCompatV7
     implementation Deps.SupportLibrary.preferenceV7
     implementation Deps.Kotlin.stdlib
+
+    // core
     implementation project(":kotpref")
+
+    // initializer
     implementation project(":initializer")
+
+    // enum support
     implementation project(":enum-support")
+
+    // gson support
     implementation project(":gson-support")
+    implementation Deps.gson
+
+    // LiveData support
     implementation project(":livedata-support")
+    implementation Deps.Arch.liveData
+    implementation Deps.Kotlin.reflect
 }
 


### PR DESCRIPTION
Change kotlin stdlib, reflect and other third party libraries dependent type to prevent implicit version transitive