### PR TITLE
Extract jacoco settings to helper plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,9 @@ buildscript {
 }
 
 allprojects {
-    apply plugin: 'jacoco'
     repositories {
         jcenter()
         google()
-    }
-    jacoco {
-        toolVersion = "0.7.9"
     }
 }
 
@@ -48,30 +44,4 @@ task replaceVersionInReadme() {
     ant.replaceregexp(match: 'kotlin-([0-9\\.]+)-blue\\.svg', replace: "kotlin-${Versions.kotlin}-blue.svg", flags: 'g') {
         fileset(dir: project.projectDir, includes: 'README.md')
     }
-}
-
-configure(subprojects.findAll { it.name != 'sample' }) {
-    task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
-
-        reports {
-            xml.enabled = true
-            html.enabled = true
-        }
-
-        def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*']
-        def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
-        def kotlinDebugTree = fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug", excludes: fileFilter)
-        def mainSrc = "${project.projectDir}/src/main/kotlin"
-
-        sourceDirectories = files([mainSrc])
-        classDirectories = files([debugTree], [kotlinDebugTree])
-        executionData = fileTree(dir: "$buildDir", includes: [
-                "jacoco/testDebugUnitTest.exec"
-        ])
-    }
-}
-
-static def env(String name, String defValue) {
-    def value = System.getenv()[name]
-    return value == null ? defValue : value
 }

--- a/buildSrc/src/main/java/plugin/BuildSettingHelperPlugin.kt
+++ b/buildSrc/src/main/java/plugin/BuildSettingHelperPlugin.kt
@@ -1,0 +1,52 @@
+package plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.closureOf
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
+class BuildSettingHelperPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.extensions.add("isCi", System.getenv("CI")?.toBoolean() ?: false)
+        addJacocoSettings(project)
+    }
+
+    private fun addJacocoSettings(project: Project) {
+        project.closureOf<JacocoPluginExtension> {
+            toolVersion = "0.8.0"
+        }
+        project.tasks.create("jacocoTestReport", JacocoReport::class.java) {
+            dependsOn("testDebugUnitTest")
+            reports {
+                xml.isEnabled = true
+                html.isEnabled = true
+            }
+            val fileFilter = listOf(
+                "**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*"
+            )
+            val debugTree = project.fileTree(
+                mapOf(
+                    "dir" to "${project.buildDir}/intermediates/classes/debug",
+                    "excludes" to fileFilter
+                )
+            )
+            val kotlinDebugTree = project.fileTree(
+                mapOf(
+                    "dir" to "${project.buildDir}/tmp/kotlin-classes/debug",
+                    "excludes" to fileFilter
+                )
+            )
+            val mainSrc = "${project.projectDir}/src/main/kotlin"
+            sourceDirectories = project.files(listOf(mainSrc))
+            classDirectories = project.files(listOf(debugTree, kotlinDebugTree))
+            executionData = project.fileTree(
+                mapOf(
+                    "dir" to project.buildDir.toString(),
+                    "includes" to listOf("jacoco/testDebugUnitTest.exec")
+                )
+            )
+        }
+    }
+}

--- a/enum-support/build.gradle
+++ b/enum-support/build.gradle
@@ -1,8 +1,11 @@
 import dependencies.Deps
 import dependencies.Versions
+import plugin.BuildSettingHelperPlugin
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'jacoco'
+apply plugin: BuildSettingHelperPlugin
 
 ext.moduleName = 'Kotpref enum support'
 
@@ -17,7 +20,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled env("CI", "false") == "true"
+            testCoverageEnabled isCi
         }
         release {
             minifyEnabled false

--- a/gson-support/build.gradle
+++ b/gson-support/build.gradle
@@ -1,8 +1,11 @@
 import dependencies.Deps
 import dependencies.Versions
+import plugin.BuildSettingHelperPlugin
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'jacoco'
+apply plugin: BuildSettingHelperPlugin
 
 ext.moduleName = 'Kotpref gson support'
 
@@ -17,7 +20,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled env("CI", "false") == "true"
+            testCoverageEnabled isCi
         }
         release {
             minifyEnabled false

--- a/initializer/build.gradle
+++ b/initializer/build.gradle
@@ -1,8 +1,11 @@
 import dependencies.Deps
 import dependencies.Versions
+import plugin.BuildSettingHelperPlugin
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'jacoco'
+apply plugin: BuildSettingHelperPlugin
 
 ext.moduleName = 'Kotpref auto initializer'
 
@@ -17,7 +20,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled env("CI", "false") == "true"
+            testCoverageEnabled isCi
         }
         release {
             minifyEnabled false

--- a/kotpref/build.gradle
+++ b/kotpref/build.gradle
@@ -1,8 +1,11 @@
 import dependencies.Deps
 import dependencies.Versions
+import plugin.BuildSettingHelperPlugin
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'jacoco'
+apply plugin: BuildSettingHelperPlugin
 
 ext.moduleName = 'Kotpref'
 
@@ -19,7 +22,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled env("CI", "false") == "true"
+            testCoverageEnabled isCi
         }
         release {
             minifyEnabled false

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -1,8 +1,11 @@
 import dependencies.Deps
 import dependencies.Versions
+import plugin.BuildSettingHelperPlugin
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'jacoco'
+apply plugin: BuildSettingHelperPlugin
 
 ext.moduleName = 'Kotpref LiveData support'
 
@@ -17,7 +20,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled env("CI", "false") == "true"
+            testCoverageEnabled isCi
         }
         release {
             minifyEnabled false


### PR DESCRIPTION
Extract common jacoco settings to helper plugin.
It cause to simplify build.gradle file.