### PR TITLE
Introduce injectable context

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ Kotpref.init(context)
 
 or use auto initializer module.
 
+### Injectable Context
+
+If you don't want to use singleton context because of unit test or etc.., you can use secondary 
+constructor of KotprefModel to inject context.  
+
+```kotlin
+class InjectableContextSamplePref(context: Context) : KotprefModel(context) {
+    var sampleData by stringPref()
+}
+```
+
+If you set context to all your model, you don't need call `Kotpref.init(context)` and don't use auto initializer module.
+
 ### Read and Write
 
 ```kotlin

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/ContextProvider.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/ContextProvider.kt
@@ -1,0 +1,7 @@
+package com.chibatching.kotpref
+
+import android.content.Context
+
+interface ContextProvider {
+    fun getApplicationContext(): Context
+}

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/Kotpref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/Kotpref.kt
@@ -1,22 +1,11 @@
 package com.chibatching.kotpref
 
-import android.annotation.SuppressLint
 import android.content.Context
 
 /**
  * Kotpref: SharedPreference delegation for Kotlin
  */
-@SuppressLint("StaticFieldLeak")
 object Kotpref {
-
-    /**
-     * Internal context. If context is not set, Kotpref will throw [IllegalStateException].
-     */
-    internal var context: Context? = null
-        get() {
-            return field ?: throw IllegalStateException("Kotpref has not been initialized.")
-        }
-        private set
 
     /**
      * Initialize Kotpref singleton object.
@@ -24,6 +13,6 @@ object Kotpref {
      * @param context Application context
      */
     fun init(context: Context) {
-        this.context = context.applicationContext
+        StaticContextProvider.setContext(context.applicationContext)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
@@ -12,15 +12,24 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.properties.ReadWriteProperty
 
 
-abstract class KotprefModel {
+abstract class KotprefModel(
+    private val contextProvider: ContextProvider = StaticContextProvider
+) {
+
+    constructor(context: Context) : this(object : ContextProvider {
+        override fun getApplicationContext(): Context {
+            return context.applicationContext
+        }
+    })
 
     internal var kotprefInTransaction: Boolean = false
     internal var kotprefTransactionStartTime: Long = 0
 
     /**
-     * Context set to Kotpref
+     * Application Context
      */
-    val context: Context by lazy { Kotpref.context!! }
+    val context: Context
+        get() = contextProvider.getApplicationContext()
 
     /**
      * Preference file name

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/StaticContextProvider.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/StaticContextProvider.kt
@@ -1,0 +1,18 @@
+package com.chibatching.kotpref
+
+import android.content.Context
+
+
+internal object StaticContextProvider : ContextProvider {
+
+    private var staticContext: Context? = null
+
+    override fun getApplicationContext(): Context {
+        return staticContext
+            ?: throw IllegalStateException("StaticContextProvider has not been initialized.")
+    }
+
+    fun setContext(context: Context) {
+        staticContext = context.applicationContext
+    }
+}

--- a/kotpref/src/test/java/com/chibatching/kotpref/BlockingBulkEditTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/BlockingBulkEditTest.kt
@@ -1,7 +1,6 @@
 package com.chibatching.kotpref
 
 import android.annotation.TargetApi
-import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import org.assertj.core.api.Assertions.assertThat
@@ -27,14 +26,11 @@ class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
     }
 
     lateinit var example: Example
-    lateinit var context: Context
     lateinit var pref: SharedPreferences
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
-        Kotpref.init(context)
-        example = Example(commitAllProperties)
+        example = Example(commitAllProperties, RuntimeEnvironment.application)
 
         pref = example.preferences
         pref.edit().clear().commit()
@@ -112,7 +108,10 @@ class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
 
             assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1")
         }
-        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test3")
+        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+            "test1",
+            "test3"
+        )
     }
 
     @Test
@@ -148,7 +147,11 @@ class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
 
             assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1")
         }
-        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test2", "test3")
+        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+            "test1",
+            "test2",
+            "test3"
+        )
     }
 
     @Test
@@ -190,7 +193,11 @@ class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
         example.blockingBulk {
             testStringSet.removeAll(removeSet)
 
-            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test2", "test3")
+            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+                "test1",
+                "test2",
+                "test3"
+            )
         }
         assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test2")
     }
@@ -236,9 +243,16 @@ class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
         example.blockingBulk {
             testStringSet.retainAll(retainSet)
 
-            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test2", "test3")
+            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+                "test1",
+                "test2",
+                "test3"
+            )
         }
-        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test3")
+        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+            "test1",
+            "test3"
+        )
     }
 
     @Test

--- a/kotpref/src/test/java/com/chibatching/kotpref/BulkEditTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/BulkEditTest.kt
@@ -1,7 +1,6 @@
 package com.chibatching.kotpref
 
 import android.annotation.TargetApi
-import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import org.assertj.core.api.Assertions.assertThat
@@ -25,14 +24,11 @@ class BulkEditTest(private val commitAllProperties: Boolean) {
     }
 
     lateinit var example: Example
-    lateinit var context: Context
     lateinit var pref: SharedPreferences
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
-        Kotpref.init(context)
-        example = Example(commitAllProperties)
+        example = Example(commitAllProperties, RuntimeEnvironment.application)
 
         pref = example.preferences
         pref.edit().clear().commit()
@@ -110,7 +106,10 @@ class BulkEditTest(private val commitAllProperties: Boolean) {
 
             assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1")
         }
-        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test3")
+        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+            "test1",
+            "test3"
+        )
     }
 
     @Test
@@ -146,7 +145,11 @@ class BulkEditTest(private val commitAllProperties: Boolean) {
 
             assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1")
         }
-        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test2", "test3")
+        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+            "test1",
+            "test2",
+            "test3"
+        )
     }
 
     @Test
@@ -188,7 +191,11 @@ class BulkEditTest(private val commitAllProperties: Boolean) {
         example.bulk {
             testStringSet.removeAll(removeSet)
 
-            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test2", "test3")
+            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+                "test1",
+                "test2",
+                "test3"
+            )
         }
         assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test2")
     }
@@ -234,9 +241,16 @@ class BulkEditTest(private val commitAllProperties: Boolean) {
         example.bulk {
             testStringSet.retainAll(retainSet)
 
-            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test2", "test3")
+            assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+                "test1",
+                "test2",
+                "test3"
+            )
         }
-        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder("test1", "test3")
+        assertThat(pref.getStringSet("testStringSet", null)).containsExactlyInAnyOrder(
+            "test1",
+            "test3"
+        )
     }
 
     @Test

--- a/kotpref/src/test/java/com/chibatching/kotpref/CustomExample.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/CustomExample.kt
@@ -1,9 +1,13 @@
 package com.chibatching.kotpref
 
+import android.content.Context
 import java.util.*
 
 
-class CustomExample(private val commitAllProperties: Boolean) : KotprefModel() {
+class CustomExample(
+    private val commitAllProperties: Boolean, context: Context
+) : KotprefModel(context) {
+
     override val commitAllPropertiesByDefault: Boolean
         get() = commitAllProperties
 
@@ -17,7 +21,10 @@ class CustomExample(private val commitAllProperties: Boolean) : KotprefModel() {
     var testFloat by floatPref(Float.MAX_VALUE, R.string.test_custom_float)
     var testBoolean by booleanPref(true, R.string.test_custom_boolean)
     var testString by stringPref("default", R.string.test_custom_string)
-    var testStringNullable by nullableStringPref("nullable default", R.string.test_custom_nullable_string)
+    var testStringNullable by nullableStringPref(
+        "nullable default",
+        R.string.test_custom_nullable_string
+    )
     val testStringSet by stringSetPref(R.string.test_custom_string_set) {
         val defSet = LinkedHashSet<String>()
         defSet.add("Lazy set item 1")

--- a/kotpref/src/test/java/com/chibatching/kotpref/Example.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/Example.kt
@@ -1,9 +1,10 @@
 package com.chibatching.kotpref
 
+import android.content.Context
 import java.util.*
 
 
-class Example(private val commitAllProperties: Boolean) : KotprefModel() {
+class Example(private val commitAllProperties: Boolean, context: Context) : KotprefModel(context) {
     override val commitAllPropertiesByDefault: Boolean
         get() = commitAllProperties
 

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/BasePrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/BasePrefTest.kt
@@ -21,9 +21,8 @@ abstract class BasePrefTest(private val commitAllProperties: Boolean) {
     @Before
     fun setUp() {
         context = RuntimeEnvironment.application
-        Kotpref.init(context)
-        example = Example(commitAllProperties)
-        customExample = CustomExample(commitAllProperties)
+        example = Example(commitAllProperties, context)
+        customExample = CustomExample(commitAllProperties, context)
 
         examplePref = example.preferences
         examplePref.edit().clear().commit()

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -32,5 +32,11 @@
             android:parentActivityName=".MainActivity"
             tools:targetApi="jelly_bean"
         />
+        <activity
+            android:name=".injectablecontext.InjectableContextSampleActivity"
+            android:label="@string/injectable_context_sample"
+            android:parentActivityName=".MainActivity"
+            tools:targetApi="jelly_bean"
+        />
     </application>
 </manifest>

--- a/sample/src/main/kotlin/com/chibatching/kotprefsample/injectablecontext/InjectableContextSample.kt
+++ b/sample/src/main/kotlin/com/chibatching/kotprefsample/injectablecontext/InjectableContextSample.kt
@@ -1,0 +1,9 @@
+package com.chibatching.kotprefsample.injectablecontext
+
+import android.content.Context
+import com.chibatching.kotpref.KotprefModel
+
+class InjectableContextSample(context: Context) : KotprefModel(context) {
+
+    var sampleData by stringPref()
+}

--- a/sample/src/main/kotlin/com/chibatching/kotprefsample/injectablecontext/InjectableContextSampleActivity.kt
+++ b/sample/src/main/kotlin/com/chibatching/kotprefsample/injectablecontext/InjectableContextSampleActivity.kt
@@ -1,0 +1,32 @@
+package com.chibatching.kotprefsample.injectablecontext
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.chibatching.kotprefsample.R
+import kotlinx.android.synthetic.main.activity_injectable_context_sample.*
+
+class InjectableContextSampleActivity : AppCompatActivity() {
+
+    private val injectableContextData by lazy {
+        InjectableContextSample(this)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_injectable_context_sample)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        saveButton.setOnClickListener {
+            injectableContextData.sampleData = editText.text.toString()
+            textView.text = injectableContextData.sampleData
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        if (super.onSupportNavigateUp()) {
+            return true
+        }
+        finish()
+        return true
+    }
+}

--- a/sample/src/main/res/layout/activity_injectable_context_sample.xml
+++ b/sample/src/main/res/layout/activity_injectable_context_sample.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.chibatching.kotprefsample.livedata.LiveDataSampleActivity"
+>
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:gravity="center_horizontal"
+        android:lines="1"
+    />
+    <EditText
+        android:id="@+id/editText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:inputType="text"
+        android:lines="1"
+    />
+    <Button
+        android:id="@+id/saveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/save"
+    />
+</LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="preference_fragment_sample">PreferenceFragment sample</string>
     <string name="live_data_sample">LiveData sample</string>
+    <string name="injectable_context_sample">LiveData sample</string>
     <string name="save">Save</string>
 
     <!-- Sample preference fragment -->


### PR DESCRIPTION
I introduced injectable context to KotprefModel.
Now, we can set the context through its constructor.
This made more easily unit testing with robolectric.

You just set the context from the application/activity/fragment and DI like Dagger to the model constructor and pass it to KotprefModel.

```kotlin
class InjectableContextSamplePref(context: Context) : KotprefModel(context) {
    var sampleData by stringPref()
}
```