### PR TITLE
Migrate to robolectric 4.0

### DIFF
--- a/buildSrc/src/main/java/dependencies/Deps.kt
+++ b/buildSrc/src/main/java/dependencies/Deps.kt
@@ -26,6 +26,7 @@ object Deps {
     object AndroidX {
         val appCompat = "androidx.appcompat:appcompat:${Versions.AndroidX.appCompat}"
         val preference = "androidx.preference:preference:${Versions.AndroidX.preference}"
+        val test = "androidx.test:core:${Versions.AndroidX.test}"
     }
 
     object Mockito {

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -10,7 +10,7 @@ object Versions {
 
     internal const val kotlin = "1.3.10"
     internal const val junit = "4.12"
-    internal const val robolectric = "3.8"
+    internal const val robolectric = "4.0.2"
     internal const val assertj = "3.11.1"
     internal const val gson = "2.8.5"
     internal const val liveData = "2.0.0"
@@ -27,5 +27,6 @@ object Versions {
     internal object AndroidX {
         internal const val appCompat = "1.0.0"
         internal const val preference = "1.0.0"
+        internal const val test = "1.0.0"
     }
 }

--- a/enum-support/build.gradle
+++ b/enum-support/build.gradle
@@ -30,10 +30,13 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     testOptions {
-        unitTests.all {
-            jacoco {
-                includeNoLocationClasses = true
+        unitTests {
+            all {
+                jacoco {
+                    includeNoLocationClasses = true
+                }
             }
+            includeAndroidResources = true
         }
     }
 }
@@ -45,6 +48,7 @@ dependencies {
     testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.junit
     testImplementation Deps.robolectric
+    testImplementation Deps.AndroidX.test
     testImplementation Deps.assertj
 }
 

--- a/enum-support/src/test/AndroidManifest.xml
+++ b/enum-support/src/test/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest package="com.chibatching.kotpref.enumpref">
+
+</manifest>

--- a/enum-support/src/test/java/com/chibatching/kotpref/enumpref/EnumSupportTest.kt
+++ b/enum-support/src/test/java/com/chibatching/kotpref/enumpref/EnumSupportTest.kt
@@ -2,7 +2,7 @@ package com.chibatching.kotpref.enumpref
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.chibatching.kotpref.Kotpref
+import androidx.test.core.app.ApplicationProvider
 import com.chibatching.kotpref.KotprefModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -10,10 +10,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 import java.util.*
 
-
+@Config(manifest = Config.NONE)
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class EnumSupportTest(private val commitAllProperties: Boolean) {
 
@@ -25,7 +25,8 @@ class EnumSupportTest(private val commitAllProperties: Boolean) {
         }
     }
 
-    class Example(private val commitAllProperties: Boolean) : KotprefModel() {
+    class Example(private val commitAllProperties: Boolean) :
+        KotprefModel(ApplicationProvider.getApplicationContext<Context>()) {
         override val commitAllPropertiesByDefault: Boolean
             get() = commitAllProperties
 
@@ -34,14 +35,11 @@ class EnumSupportTest(private val commitAllProperties: Boolean) {
         var testEnumOrdinal by enumOrdinalPref(ExampleEnum.FIRST)
     }
 
-    lateinit var example: Example
-    lateinit var context: Context
-    lateinit var pref: SharedPreferences
+    private lateinit var example: Example
+    private lateinit var pref: SharedPreferences
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
-        Kotpref.init(context)
         example = Example(commitAllProperties)
 
         pref = example.preferences
@@ -74,7 +72,12 @@ class EnumSupportTest(private val commitAllProperties: Boolean) {
     fun setEnumNullableValuePrefCausePreferenceUpdate() {
         example.testEnumNullableValue = ExampleEnum.SECOND
         assertThat(example.testEnumNullableValue).isEqualTo(ExampleEnum.SECOND)
-        assertThat(example.testEnumNullableValue!!.name).isEqualTo(pref.getString("testEnumNullableValue", ""))
+        assertThat(example.testEnumNullableValue!!.name).isEqualTo(
+            pref.getString(
+                "testEnumNullableValue",
+                ""
+            )
+        )
     }
 
     @Test

--- a/enum-support/src/test/resources/robolectric.properties
+++ b/enum-support/src/test/resources/robolectric.properties
@@ -1,2 +1,1 @@
-packageName=com.chibatching.kotpref
 sdk=27

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,4 @@ org.gradle.jvmargs=-Xmx1536M
 org.gradle.parallel=true
 org.gradle.caching=true
 android.useAndroidX=true
+android.enableUnitTestBinaryResources=true

--- a/gson-support/build.gradle
+++ b/gson-support/build.gradle
@@ -30,10 +30,13 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     testOptions {
-        unitTests.all {
-            jacoco {
-                includeNoLocationClasses = true
+        unitTests {
+            all {
+                jacoco {
+                    includeNoLocationClasses = true
+                }
             }
+            includeAndroidResources = true
         }
     }
 }
@@ -48,6 +51,7 @@ dependencies {
     testImplementation Deps.gson
     testImplementation Deps.junit
     testImplementation Deps.robolectric
+    testImplementation Deps.AndroidX.test
     testImplementation Deps.assertj
 }
 

--- a/gson-support/src/main/AndroidManifest.xml
+++ b/gson-support/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
 <manifest package="com.chibatching.kotpref.gsonpref">
 
-    <application />
-
 </manifest>

--- a/gson-support/src/test/AndroidManifest.xml
+++ b/gson-support/src/test/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.chibatching.kotpref.enumpref"
+    package="com.chibatching.kotpref.gsonpref"
 >
 
     <uses-sdk tools:overrideLibrary="androidx.test,androidx.test.core"/>

--- a/gson-support/src/test/java/com/chibatching/kotpref/gsonpref/GsonSupportTest.kt
+++ b/gson-support/src/test/java/com/chibatching/kotpref/gsonpref/GsonSupportTest.kt
@@ -2,6 +2,7 @@ package com.chibatching.kotpref.gsonpref
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import com.chibatching.kotpref.Kotpref
 import com.chibatching.kotpref.KotprefModel
 import com.google.gson.Gson
@@ -12,7 +13,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.util.*
 
 
@@ -39,7 +39,8 @@ class GsonSupportTest(private val commitAllProperties: Boolean) {
             }.time
     }
 
-    class Example(private val commitAllProperties: Boolean) : KotprefModel() {
+    class Example(private val commitAllProperties: Boolean) :
+        KotprefModel(ApplicationProvider.getApplicationContext<Context>()) {
         override val commitAllPropertiesByDefault: Boolean
             get() = commitAllProperties
 
@@ -50,14 +51,11 @@ class GsonSupportTest(private val commitAllProperties: Boolean) {
         var nullableContent: Content? by gsonNullablePref()
     }
 
-    lateinit var example: Example
-    lateinit var context: Context
-    lateinit var pref: SharedPreferences
+    private lateinit var example: Example
+    private lateinit var pref: SharedPreferences
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
-        Kotpref.init(context)
         Kotpref.gson = Gson()
         example = Example(commitAllProperties)
 

--- a/gson-support/src/test/resources/robolectric.properties
+++ b/gson-support/src/test/resources/robolectric.properties
@@ -1,2 +1,1 @@
-packageName=com.chibatching.kotpref
 sdk=27

--- a/kotpref/build.gradle
+++ b/kotpref/build.gradle
@@ -33,10 +33,12 @@ android {
     }
     testOptions {
         unitTests {
-            includeAndroidResources = true
             all {
-                jacoco.includeNoLocationClasses = true
+                jacoco {
+                    includeNoLocationClasses = true
+                }
             }
+            includeAndroidResources = true
         }
     }
 }
@@ -47,6 +49,7 @@ dependencies {
     testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.junit
     testImplementation Deps.robolectric
+    testImplementation Deps.AndroidX.test
     testImplementation Deps.assertj
 }
 

--- a/kotpref/src/main/AndroidManifest.xml
+++ b/kotpref/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <manifest package="com.chibatching.kotpref">
 
-    <application/>
 </manifest>

--- a/kotpref/src/test/AndroidManifest.xml
+++ b/kotpref/src/test/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.chibatching.kotpref.enumpref"
+    package="com.chibatching.kotpref"
 >
 
     <uses-sdk tools:overrideLibrary="androidx.test,androidx.test.core"/>
-
 </manifest>

--- a/kotpref/src/test/java/com/chibatching/kotpref/BlockingBulkEditTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/BlockingBulkEditTest.kt
@@ -3,13 +3,13 @@ package com.chibatching.kotpref
 import android.annotation.TargetApi
 import android.content.SharedPreferences
 import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.util.*
 
@@ -30,7 +30,7 @@ class BlockingBulkEditTest(private val commitAllProperties: Boolean) {
 
     @Before
     fun setUp() {
-        example = Example(commitAllProperties, RuntimeEnvironment.application)
+        example = Example(commitAllProperties, ApplicationProvider.getApplicationContext())
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/kotpref/src/test/java/com/chibatching/kotpref/BulkEditTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/BulkEditTest.kt
@@ -3,13 +3,13 @@ package com.chibatching.kotpref
 import android.annotation.TargetApi
 import android.content.SharedPreferences
 import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.util.*
 
 
@@ -28,7 +28,7 @@ class BulkEditTest(private val commitAllProperties: Boolean) {
 
     @Before
     fun setUp() {
-        example = Example(commitAllProperties, RuntimeEnvironment.application)
+        example = Example(commitAllProperties, ApplicationProvider.getApplicationContext())
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/BasePrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/BasePrefTest.kt
@@ -2,12 +2,11 @@ package com.chibatching.kotpref.pref
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
 import com.chibatching.kotpref.CustomExample
 import com.chibatching.kotpref.Example
-import com.chibatching.kotpref.Kotpref
 import org.junit.After
 import org.junit.Before
-import org.robolectric.RuntimeEnvironment
 
 
 abstract class BasePrefTest(private val commitAllProperties: Boolean) {
@@ -20,7 +19,7 @@ abstract class BasePrefTest(private val commitAllProperties: Boolean) {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
+        context = ApplicationProvider.getApplicationContext()
         example = Example(commitAllProperties, context)
         customExample = CustomExample(commitAllProperties, context)
 

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -30,10 +30,13 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     testOptions {
-        unitTests.all {
-            jacoco {
-                includeNoLocationClasses = true
+        unitTests {
+            all {
+                jacoco {
+                    includeNoLocationClasses = true
+                }
             }
+            includeAndroidResources = true
         }
     }
 }
@@ -50,6 +53,7 @@ dependencies {
     testImplementation Deps.Arch.liveData
     testImplementation Deps.junit
     testImplementation Deps.robolectric
+    testImplementation Deps.AndroidX.test
     testImplementation Deps.assertj
 }
 

--- a/livedata-support/src/main/AndroidManifest.xml
+++ b/livedata-support/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
-<manifest package="com.chibatching.kotpref.livedata">
+<manifest
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.chibatching.kotpref.livedata"
+>
 
-    <application />
+    <uses-sdk tools:overrideLibrary="androidx.test,androidx.test.core"/>
 
 </manifest>

--- a/livedata-support/src/test/AndroidManifest.xml
+++ b/livedata-support/src/test/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest package="com.chibatching.kotpref.livedata">
+
+</manifest>

--- a/livedata-support/src/test/java/com/chibatching/kotpref/livedata/LiveDataSupportTest.kt
+++ b/livedata-support/src/test/java/com/chibatching/kotpref/livedata/LiveDataSupportTest.kt
@@ -3,7 +3,7 @@ package com.chibatching.kotpref.livedata
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.lifecycle.Observer
-import com.chibatching.kotpref.Kotpref
+import androidx.test.core.app.ApplicationProvider
 import com.chibatching.kotpref.KotprefModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -11,27 +11,23 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 
 @RunWith(RobolectricTestRunner::class)
 class LiveDataSupportTest {
-    class Example : KotprefModel() {
+    class Example(context: Context) : KotprefModel(context) {
         var someProperty by stringPref("default")
         var customKeyProperty by intPref(8, "custom_key")
     }
 
     lateinit var example: Example
-    lateinit var context: Context
     lateinit var pref: SharedPreferences
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
-        Kotpref.init(context)
-        example = Example()
+        example = Example(ApplicationProvider.getApplicationContext())
 
         pref = example.preferences
         pref.edit().clear().commit()


### PR DESCRIPTION
Migrate from Robolectric 3.8 to Robolectric 4.0.
ref: http://robolectric.org/migrating/#migrating-to-40

Including small refactor to inject context as the constructor parameter.