### PR TITLE
Allow read/write access from other preference instance

### DIFF
--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
@@ -23,7 +23,7 @@ abstract class KotprefModel(
     })
 
     internal var kotprefInTransaction: Boolean = false
-    internal var kotprefTransactionStartTime: Long = 0
+    internal var kotprefTransactionStartTime: Long = Long.MAX_VALUE
 
     /**
      * Application Context

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
@@ -23,16 +23,17 @@ internal class StringSetPref(
         thisRef: KotprefModel,
         property: KProperty<*>
     ): MutableSet<String> {
-        if (stringSet == null || lastUpdate < thisRef.kotprefTransactionStartTime) {
-            val prefSet = thisRef.kotprefPreference.getStringSet(key ?: property.name, null)
-                ?.let { HashSet(it) }
-            stringSet = PrefMutableSet(
-                thisRef,
-                prefSet ?: default.invoke().toMutableSet(),
-                key ?: property.name
-            )
-            lastUpdate = SystemClock.uptimeMillis()
+        if (stringSet != null && lastUpdate >= thisRef.kotprefTransactionStartTime) {
+            return stringSet!!
         }
+        val prefSet = thisRef.kotprefPreference.getStringSet(key ?: property.name, null)
+            ?.let { HashSet(it) }
+        stringSet = PrefMutableSet(
+            thisRef,
+            prefSet ?: default.invoke().toMutableSet(),
+            key ?: property.name
+        )
+        lastUpdate = SystemClock.uptimeMillis()
         return stringSet!!
     }
 

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/BooleanPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/BooleanPrefTest.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref.pref
 
+import android.content.Context
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -42,6 +43,36 @@ class BooleanPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProp
         customExample.testBoolean = false
         assertThat(customExample.testBoolean)
             .isEqualTo(false)
-            .isEqualTo(customPref.getBoolean(context.getString(R.string.test_custom_boolean), false))
+            .isEqualTo(
+                customPref.getBoolean(
+                    context.getString(R.string.test_custom_boolean),
+                    false
+                )
+            )
+    }
+
+    @Test
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testBoolean = true
+
+        assertThat(otherPreference.getBoolean("testBoolean", false))
+            .isTrue()
+    }
+
+    @Test
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testBoolean
+
+        otherPreference.edit()
+            .putBoolean("testBoolean", true)
+            .commit()
+
+        assertThat(example.testBoolean).isTrue()
     }
 }

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/FloatPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/FloatPrefTest.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref.pref
 
+import android.content.Context
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -42,5 +43,30 @@ class FloatPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProper
         assertThat(customExample.testFloat)
             .isEqualTo(309F)
             .isEqualTo(customPref.getFloat(context.getString(R.string.test_custom_float), 0F))
+    }
+
+    @Test
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testFloat = 100F
+
+        assertThat(otherPreference.getFloat("testFloat", 0F))
+            .isEqualTo(100F)
+    }
+
+    @Test
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testFloat
+
+        otherPreference.edit()
+            .putFloat("testFloat", 120F)
+            .commit()
+
+        assertThat(example.testFloat).isEqualTo(120F)
     }
 }

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/IntPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/IntPrefTest.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref.pref
 
+import android.content.Context
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -42,5 +43,30 @@ class IntPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllProperti
         assertThat(customExample.testInt)
             .isEqualTo(29)
             .isEqualTo(customPref.getInt(context.getString(R.string.test_custom_int), 0))
+    }
+
+    @Test
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testInt = 20
+
+        assertThat(otherPreference.getInt("testInt", 0))
+            .isEqualTo(20)
+    }
+
+    @Test
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testInt
+
+        otherPreference.edit()
+            .putInt("testInt", 50)
+            .commit()
+
+        assertThat(example.testInt).isEqualTo(50)
     }
 }

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/LongPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/LongPrefTest.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref.pref
 
+import android.content.Context
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -42,5 +43,30 @@ class LongPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllPropert
         assertThat(customExample.testLong)
             .isEqualTo(296201L)
             .isEqualTo(customPref.getLong(context.getString(R.string.test_custom_long), 0L))
+    }
+
+    @Test
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testLong = 40L
+
+        assertThat(otherPreference.getLong("testFloat", 40L))
+            .isEqualTo(40L)
+    }
+
+    @Test
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testLong
+
+        otherPreference.edit()
+            .putLong("testLong", 10L)
+            .commit()
+
+        assertThat(example.testLong).isEqualTo(10L)
     }
 }

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/StringNullablePrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/StringNullablePrefTest.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref.pref
 
+import android.content.Context
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -41,6 +42,36 @@ class StringNullablePrefTest(commitAllProperties: Boolean) : BasePrefTest(commit
         customExample.testStringNullable = "Hello"
         assertThat(customExample.testStringNullable)
             .isEqualTo("Hello")
-            .isEqualTo(customPref.getString(context.getString(R.string.test_custom_nullable_string), null))
+            .isEqualTo(
+                customPref.getString(
+                    context.getString(R.string.test_custom_nullable_string),
+                    null
+                )
+            )
+    }
+
+    @Test
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testStringNullable = "Hello world"
+
+        assertThat(otherPreference.getString("testStringNullable", null))
+            .isEqualTo("Hello world")
+    }
+
+    @Test
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testStringNullable
+
+        otherPreference.edit()
+            .putString("testStringNullable", "Hello world")
+            .commit()
+
+        assertThat(example.testStringNullable).isEqualTo("Hello world")
     }
 }

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/StringPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/StringPrefTest.kt
@@ -1,5 +1,6 @@
 package com.chibatching.kotpref.pref
 
+import android.content.Context
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -42,5 +43,30 @@ class StringPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllPrope
         assertThat(customExample.testString)
             .isEqualTo("Hello")
             .isEqualTo(customPref.getString(context.getString(R.string.test_custom_string), null))
+    }
+
+    @Test
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testStringNullable = "Hello world"
+
+        assertThat(otherPreference.getString("testStringNullable", null))
+            .isEqualTo("Hello world")
+    }
+
+    @Test
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testString
+
+        otherPreference.edit()
+            .putString("testStringNullable", "Hello world")
+            .commit()
+
+        assertThat(example.testStringNullable).isEqualTo("Hello world")
     }
 }

--- a/kotpref/src/test/java/com/chibatching/kotpref/pref/StringSetPrefTest.kt
+++ b/kotpref/src/test/java/com/chibatching/kotpref/pref/StringSetPrefTest.kt
@@ -1,6 +1,7 @@
 package com.chibatching.kotpref.pref
 
 import android.annotation.TargetApi
+import android.content.Context
 import android.os.Build
 import com.chibatching.kotpref.R
 import org.assertj.core.api.Assertions.assertThat
@@ -112,9 +113,24 @@ class StringSetPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllPr
     fun useCustomPreferenceKey() {
         customExample.testStringSet.add("Additional item")
         assertThat(customExample.testStringSet)
-            .containsExactlyInAnyOrder("Lazy set item 1", "Lazy set item 2", "Lazy set item 3", "Additional item")
-            .containsAll(customPref.getStringSet(context.getString(R.string.test_custom_string_set), null))
-            .hasSameSizeAs(customPref.getStringSet(context.getString(R.string.test_custom_string_set), null))
+            .containsExactlyInAnyOrder(
+                "Lazy set item 1",
+                "Lazy set item 2",
+                "Lazy set item 3",
+                "Additional item"
+            )
+            .containsAll(
+                customPref.getStringSet(
+                    context.getString(R.string.test_custom_string_set),
+                    null
+                )
+            )
+            .hasSameSizeAs(
+                customPref.getStringSet(
+                    context.getString(R.string.test_custom_string_set),
+                    null
+                )
+            )
     }
 
     @Test
@@ -133,7 +149,36 @@ class StringSetPrefTest(commitAllProperties: Boolean) : BasePrefTest(commitAllPr
         iterator.remove()
 
         assertThat(example.testStringSet)
-            .containsExactlyInAnyOrder("test3")
+            .hasSize(1)
             .containsExactlyInAnyOrderElementsOf(examplePref.getStringSet("testStringSet", null))
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    fun readFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testStringSet.apply {
+            add("test")
+        }
+
+        assertThat(otherPreference.getStringSet("testStringSet", null))
+            .containsExactly("test")
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    fun writeFromOtherPreferenceInstance() {
+        val otherPreference =
+            context.getSharedPreferences(example.kotprefName, Context.MODE_PRIVATE)
+
+        example.testStringSet
+
+        val set = otherPreference.getStringSet("testStringSet", mutableSetOf())!!
+        set.add("test")
+        otherPreference.edit().putStringSet("testStringSet", set).commit()
+
+        assertThat(example.testStringSet).containsExactly("test")
     }
 }


### PR DESCRIPTION
Allow read/write access from other preferences instance to fix #143