### PR TITLE
Allow external preference opener to allow encrypted implementations

### DIFF
--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
@@ -19,14 +19,15 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.properties.ReadWriteProperty
 
 abstract class KotprefModel(
-    private val contextProvider: ContextProvider = StaticContextProvider
+    private val contextProvider: ContextProvider = StaticContextProvider,
+    private val opener: PreferencesOpener = defaultPreferenceOpener()
 ) {
 
-    constructor(context: Context) : this(object : ContextProvider {
+    constructor(context: Context, opener: PreferencesOpener = defaultPreferenceOpener()) : this(object : ContextProvider {
         override fun getApplicationContext(): Context {
             return context.applicationContext
         }
-    })
+    }, opener)
 
     internal var kotprefInTransaction: Boolean = false
     internal var kotprefTransactionStartTime: Long = Long.MAX_VALUE
@@ -57,7 +58,7 @@ abstract class KotprefModel(
      * This property will be initialized on use.
      */
     internal val kotprefPreference: KotprefPreferences by lazy {
-        KotprefPreferences(context.getSharedPreferences(kotprefName, kotprefMode))
+        KotprefPreferences(opener.openPreferences(context, kotprefName, kotprefMode))
     }
 
     /**

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/PreferencesOpener.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/PreferencesOpener.kt
@@ -1,0 +1,16 @@
+package com.chibatching.kotpref
+
+import android.content.Context
+import android.content.SharedPreferences
+
+interface PreferencesOpener {
+    fun openPreferences(context: Context, name: String, mode: Int): SharedPreferences
+}
+
+internal fun defaultPreferenceOpener(): PreferencesOpener = DefaultOpener()
+
+private class DefaultOpener : PreferencesOpener {
+    override fun openPreferences(context: Context, name: String, mode: Int): SharedPreferences {
+        return context.getSharedPreferences(name, mode)
+    }
+}


### PR DESCRIPTION
Allow to delegate the creation of the SharedPreferences object, so that you can combine KotPref with some libraries that encrypt preferences for instance.