### PR TITLE
Change test dependency configuration to remove dependency from pom

### DIFF
--- a/enum-support/build.gradle
+++ b/enum-support/build.gradle
@@ -45,11 +45,11 @@ dependencies {
     compileOnly Deps.Kotlin.stdlib
     api project(":kotpref")
 
-    testImplementation Deps.Kotlin.stdlib
-    testImplementation Deps.junit
-    testImplementation Deps.robolectric
-    testImplementation Deps.AndroidX.test
-    testImplementation Deps.assertj
+    testCompileOnly Deps.Kotlin.stdlib
+    testCompileOnly Deps.junit
+    testCompileOnly Deps.robolectric
+    testCompileOnly Deps.AndroidX.test
+    testCompileOnly Deps.assertj
 }
 
 apply from: "${project.rootDir}/gradle/publish/publish.gradle"

--- a/gson-support/build.gradle
+++ b/gson-support/build.gradle
@@ -47,12 +47,12 @@ dependencies {
 
     compileOnly Deps.gson
 
-    testImplementation Deps.Kotlin.stdlib
-    testImplementation Deps.gson
-    testImplementation Deps.junit
-    testImplementation Deps.robolectric
-    testImplementation Deps.AndroidX.test
-    testImplementation Deps.assertj
+    testCompileOnly Deps.Kotlin.stdlib
+    testCompileOnly Deps.gson
+    testCompileOnly Deps.junit
+    testCompileOnly Deps.robolectric
+    testCompileOnly Deps.AndroidX.test
+    testCompileOnly Deps.assertj
 }
 
 apply from: "${project.rootDir}/gradle/publish/publish.gradle"

--- a/initializer/build.gradle
+++ b/initializer/build.gradle
@@ -35,9 +35,9 @@ dependencies {
     compileOnly Deps.Kotlin.stdlib
     api project(":kotpref")
 
-    testImplementation Deps.Kotlin.stdlib
-    testImplementation Deps.junit
-    testImplementation Deps.robolectric
+    testCompileOnly Deps.Kotlin.stdlib
+    testCompileOnly Deps.junit
+    testCompileOnly Deps.robolectric
 }
 
 apply from: "${project.rootDir}/gradle/publish/publish.gradle"

--- a/kotpref/build.gradle
+++ b/kotpref/build.gradle
@@ -47,11 +47,11 @@ dependencies {
     compileOnly Deps.Kotlin.stdlib
     implementation Deps.AndroidX.annotation
 
-    testImplementation Deps.Kotlin.stdlib
-    testImplementation Deps.junit
-    testImplementation Deps.robolectric
-    testImplementation Deps.AndroidX.test
-    testImplementation Deps.assertj
+    testCompileOnly Deps.Kotlin.stdlib
+    testCompileOnly Deps.junit
+    testCompileOnly Deps.robolectric
+    testCompileOnly Deps.AndroidX.test
+    testCompileOnly Deps.assertj
 }
 
 apply from: "${project.rootDir}/gradle/publish/publish.gradle"

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -48,13 +48,13 @@ dependencies {
     compileOnly Deps.Arch.liveData
     compileOnly Deps.Kotlin.reflect
 
-    testImplementation Deps.Kotlin.stdlib
-    testImplementation Deps.Kotlin.reflect
-    testImplementation Deps.Arch.liveData
-    testImplementation Deps.junit
-    testImplementation Deps.robolectric
-    testImplementation Deps.AndroidX.test
-    testImplementation Deps.assertj
+    testCompileOnly Deps.Kotlin.stdlib
+    testCompileOnly Deps.Kotlin.reflect
+    testCompileOnly Deps.Arch.liveData
+    testCompileOnly Deps.junit
+    testCompileOnly Deps.robolectric
+    testCompileOnly Deps.AndroidX.test
+    testCompileOnly Deps.assertj
 }
 
 apply from: "${project.rootDir}/gradle/publish/publish.gradle"


### PR DESCRIPTION
I found that the pom file includes test dependencies.
It is not necessary for users, it is needed only the tests for the library.