### PR TITLE
Fix the bug that latest value cannot observed while inactive

### DIFF
--- a/buildSrc/src/main/java/dependencies/Deps.kt
+++ b/buildSrc/src/main/java/dependencies/Deps.kt
@@ -25,6 +25,7 @@ object Deps {
 
     object Arch {
         const val liveData = "androidx.lifecycle:lifecycle-livedata:${Versions.liveData}"
+        const val runtime = "androidx.lifecycle:lifecycle-runtime:${Versions.liveData}"
     }
 
     object AndroidX {

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.Kotlin.reflect
     testImplementation Deps.Arch.liveData
+    testImplementation Deps.Arch.runtime
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     testImplementation Deps.AndroidX.testCore

--- a/livedata-support/src/main/kotlin/com/chibatching/kotpref/livedata/KotprefLiveDataExtensions.kt
+++ b/livedata-support/src/main/kotlin/com/chibatching/kotpref/livedata/KotprefLiveDataExtensions.kt
@@ -26,6 +26,9 @@ fun <T> KotprefModel.asLiveData(property: KProperty0<T>): LiveData<T> {
 
         override fun onActive() {
             this@asLiveData.preferences.registerOnSharedPreferenceChangeListener(this)
+            if (value != property.get()) {
+                value = property.get()
+            }
         }
 
         override fun onInactive() {


### PR DESCRIPTION
While LiveData is inactive, LiveData value doesn't reflect the changes in shared preferences.
In this PR, when LiveData becomes active, set to LiveData value if shared preferences value was changed.