### PR TITLE
Made all property delegation functions inline according to KT-14513

### DIFF
--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty
 
 class EnumNullableValuePref<T : Enum<*>>(
     enumClass: KClass<T>,
@@ -15,17 +14,17 @@ class EnumNullableValuePref<T : Enum<*>>(
 ) : AbstractPref<T?>() {
     private val enumConstants = enumClass.java.enumConstants
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
-        val value = preference.getString(key ?: property.name, default?.name)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): T? {
+        val value = preference.getString(key ?: propertyName, default?.name)
         return enumConstants.firstOrNull { it.name == value }
     }
 
     @SuppressLint("CommitPrefEdits")
-    override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value?.name).execute(commitByDefault)
+    override fun setToPreference(propertyName: String, value: T?, preference: SharedPreferences) {
+        preference.edit().putString(key ?: propertyName, value?.name).execute(commitByDefault)
     }
 
-    override fun setToEditor(property: KProperty<*>, value: T?, editor: SharedPreferences.Editor) {
-        editor.putString(key ?: property.name, value?.name)
+    override fun setToEditor(propertyName: String, value: T?, editor: SharedPreferences.Editor) {
+        editor.putString(key ?: propertyName, value?.name)
     }
 }

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty
 
 class EnumOrdinalPref<T : Enum<*>>(
     enumClass: KClass<T>,
@@ -15,17 +14,17 @@ class EnumOrdinalPref<T : Enum<*>>(
 ) : AbstractPref<T>() {
     private val enumConstants = enumClass.java.enumConstants
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
-        val value = preference.getInt(key ?: property.name, default.ordinal)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): T {
+        val value = preference.getInt(key ?: propertyName, default.ordinal)
         return enumConstants.first { it.ordinal == value }
     }
 
     @SuppressLint("CommitPrefEdits")
-    override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
-        preference.edit().putInt(key ?: property.name, value.ordinal).execute(commitByDefault)
+    override fun setToPreference(propertyName: String, value: T, preference: SharedPreferences) {
+        preference.edit().putInt(key ?: propertyName, value.ordinal).execute(commitByDefault)
     }
 
-    override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
-        editor.putInt(key ?: property.name, value.ordinal)
+    override fun setToEditor(propertyName: String, value: T, editor: SharedPreferences.Editor) {
+        editor.putInt(key ?: propertyName, value.ordinal)
     }
 }

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty
 
 class EnumValuePref<T : Enum<*>>(
     enumClass: KClass<T>,
@@ -15,17 +14,17 @@ class EnumValuePref<T : Enum<*>>(
 ) : AbstractPref<T>() {
     private val enumConstants = enumClass.java.enumConstants
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
-        val value = preference.getString(key ?: property.name, default.name)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): T {
+        val value = preference.getString(key ?: propertyName, default.name)
         return enumConstants.first { it.name == value }
     }
 
     @SuppressLint("CommitPrefEdits")
-    override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value.name).execute(commitByDefault)
+    override fun setToPreference(propertyName: String, value: T, preference: SharedPreferences) {
+        preference.edit().putString(key ?: propertyName, value.name).execute(commitByDefault)
     }
 
-    override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
-        editor.putString(key ?: property.name, value.name)
+    override fun setToEditor(propertyName: String, value: T, editor: SharedPreferences.Editor) {
+        editor.putString(key ?: propertyName, value.name)
     }
 }

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
@@ -6,7 +6,6 @@ import com.chibatching.kotpref.Kotpref
 import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import java.lang.reflect.Type
-import kotlin.reflect.KProperty
 
 class GsonNullablePref<T : Any>(
     private val targetType: Type,
@@ -15,22 +14,22 @@ class GsonNullablePref<T : Any>(
     private val commitByDefault: Boolean
 ) : AbstractPref<T?>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
-        return preference.getString(key ?: property.name, null)?.let { json ->
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): T? {
+        return preference.getString(key ?: propertyName, null)?.let { json ->
             deserializeFromJson(json) ?: default
         }
     }
 
     @SuppressLint("CommitPrefEdits")
-    override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
+    override fun setToPreference(propertyName: String, value: T?, preference: SharedPreferences) {
         serializeToJson(value).let { json ->
-            preference.edit().putString(key ?: property.name, json).execute(commitByDefault)
+            preference.edit().putString(key ?: propertyName, json).execute(commitByDefault)
         }
     }
 
-    override fun setToEditor(property: KProperty<*>, value: T?, editor: SharedPreferences.Editor) {
+    override fun setToEditor(propertyName: String, value: T?, editor: SharedPreferences.Editor) {
         serializeToJson(value).let { json ->
-            editor.putString(key ?: property.name, json)
+            editor.putString(key ?: propertyName, json)
         }
     }
 

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
@@ -6,7 +6,6 @@ import com.chibatching.kotpref.Kotpref
 import com.chibatching.kotpref.execute
 import com.chibatching.kotpref.pref.AbstractPref
 import java.lang.reflect.Type
-import kotlin.reflect.KProperty
 
 class GsonPref<T : Any>(
     private val targetType: Type,
@@ -15,22 +14,22 @@ class GsonPref<T : Any>(
     private val commitByDefault: Boolean
 ) : AbstractPref<T>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
-        return preference.getString(key ?: property.name, null)?.let { json ->
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): T {
+        return preference.getString(key ?: propertyName, null)?.let { json ->
             deserializeFromJson(json) ?: default
         } ?: default
     }
 
     @SuppressLint("CommitPrefEdits")
-    override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
+    override fun setToPreference(propertyName: String, value: T, preference: SharedPreferences) {
         serializeToJson(value).let { json ->
-            preference.edit().putString(key ?: property.name, json).execute(commitByDefault)
+            preference.edit().putString(key ?: propertyName, json).execute(commitByDefault)
         }
     }
 
-    override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
+    override fun setToEditor(propertyName: String, value: T, editor: SharedPreferences.Editor) {
         serializeToJson(value).let { json ->
-            editor.putString(key ?: property.name, json)
+            editor.putString(key ?: propertyName, json)
         }
     }
 

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
@@ -3,7 +3,6 @@ package com.chibatching.kotpref.pref
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
-import kotlin.reflect.KProperty
 
 internal class BooleanPref(
     val default: Boolean,
@@ -11,24 +10,24 @@ internal class BooleanPref(
     private val commitByDefault: Boolean
 ) : AbstractPref<Boolean>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Boolean {
-        return preference.getBoolean(key ?: property.name, default)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): Boolean {
+        return preference.getBoolean(key ?: propertyName, default)
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(
-        property: KProperty<*>,
+        propertyName: String,
         value: Boolean,
         preference: SharedPreferences
     ) {
-        preference.edit().putBoolean(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putBoolean(key ?: propertyName, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
-        property: KProperty<*>,
+        propertyName: String,
         value: Boolean,
         editor: SharedPreferences.Editor
     ) {
-        editor.putBoolean(key ?: property.name, value)
+        editor.putBoolean(key ?: propertyName, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
@@ -3,7 +3,6 @@ package com.chibatching.kotpref.pref
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
-import kotlin.reflect.KProperty
 
 internal class FloatPref(
     val default: Float,
@@ -11,24 +10,24 @@ internal class FloatPref(
     private val commitByDefault: Boolean
 ) : AbstractPref<Float>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Float {
-        return preference.getFloat(key ?: property.name, default)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): Float {
+        return preference.getFloat(key ?: propertyName, default)
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(
-        property: KProperty<*>,
+        propertyName: String,
         value: Float,
         preference: SharedPreferences
     ) {
-        preference.edit().putFloat(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putFloat(key ?: propertyName, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
-        property: KProperty<*>,
+        propertyName: String,
         value: Float,
         editor: SharedPreferences.Editor
     ) {
-        editor.putFloat(key ?: property.name, value)
+        editor.putFloat(key ?: propertyName, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
@@ -3,7 +3,6 @@ package com.chibatching.kotpref.pref
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
-import kotlin.reflect.KProperty
 
 internal class IntPref(
     val default: Int,
@@ -11,20 +10,20 @@ internal class IntPref(
     private val commitByDefault: Boolean
 ) : AbstractPref<Int>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Int {
-        return preference.getInt(key ?: property.name, default)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): Int {
+        return preference.getInt(key ?: propertyName, default)
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(
-        property: KProperty<*>,
+        propertyName: String,
         value: Int,
         preference: SharedPreferences
     ) {
-        preference.edit().putInt(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putInt(key ?: propertyName, value).execute(commitByDefault)
     }
 
-    override fun setToEditor(property: KProperty<*>, value: Int, editor: SharedPreferences.Editor) {
-        editor.putInt(key ?: property.name, value)
+    override fun setToEditor(propertyName: String, value: Int, editor: SharedPreferences.Editor) {
+        editor.putInt(key ?: propertyName, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
@@ -3,7 +3,6 @@ package com.chibatching.kotpref.pref
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
-import kotlin.reflect.KProperty
 
 internal class LongPref(
     val default: Long,
@@ -11,24 +10,24 @@ internal class LongPref(
     private val commitByDefault: Boolean
 ) : AbstractPref<Long>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Long {
-        return preference.getLong(key ?: property.name, default)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): Long {
+        return preference.getLong(key ?: propertyName, default)
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(
-        property: KProperty<*>,
+        propertyName: String,
         value: Long,
         preference: SharedPreferences
     ) {
-        preference.edit().putLong(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putLong(key ?: propertyName, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
-        property: KProperty<*>,
+        propertyName: String,
         value: Long,
         editor: SharedPreferences.Editor
     ) {
-        editor.putLong(key ?: property.name, value)
+        editor.putLong(key ?: propertyName, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
@@ -3,7 +3,6 @@ package com.chibatching.kotpref.pref
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
-import kotlin.reflect.KProperty
 
 internal class StringNullablePref(
     val default: String?,
@@ -11,24 +10,24 @@ internal class StringNullablePref(
     private val commitByDefault: Boolean
 ) : AbstractPref<String?>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String? {
-        return preference.getString(key ?: property.name, default)
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): String? {
+        return preference.getString(key ?: propertyName, default)
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(
-        property: KProperty<*>,
+        propertyName: String,
         value: String?,
         preference: SharedPreferences
     ) {
-        preference.edit().putString(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putString(key ?: propertyName, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
-        property: KProperty<*>,
+        propertyName: String,
         value: String?,
         editor: SharedPreferences.Editor
     ) {
-        editor.putString(key ?: property.name, value)
+        editor.putString(key ?: propertyName, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
@@ -3,7 +3,6 @@ package com.chibatching.kotpref.pref
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import com.chibatching.kotpref.execute
-import kotlin.reflect.KProperty
 
 internal class StringPref(
     val default: String,
@@ -11,24 +10,24 @@ internal class StringPref(
     private val commitByDefault: Boolean
 ) : AbstractPref<String>() {
 
-    override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String {
-        return requireNotNull(preference.getString(key ?: property.name, default))
+    override fun getFromPreference(propertyName: String, preference: SharedPreferences): String {
+        return requireNotNull(preference.getString(key ?: propertyName, default))
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(
-        property: KProperty<*>,
+        propertyName: String,
         value: String,
         preference: SharedPreferences
     ) {
-        preference.edit().putString(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putString(key ?: propertyName, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
-        property: KProperty<*>,
+        propertyName: String,
         value: String,
         editor: SharedPreferences.Editor
     ) {
-        editor.putString(key ?: property.name, value)
+        editor.putString(key ?: propertyName, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
@@ -19,19 +19,27 @@ internal class StringSetPref(
     private var stringSet: MutableSet<String>? = null
     private var lastUpdate: Long = 0L
 
-    override operator fun getValue(
+    override inline operator fun getValue(
         thisRef: KotprefModel,
         property: KProperty<*>
+    ): MutableSet<String> {
+        val propertyName = property.name
+        return getValueInternal(thisRef, propertyName)
+    }
+
+    @PublishedApi internal fun StringSetPref.getValueInternal(
+        thisRef: KotprefModel,
+        propertyName: String
     ): MutableSet<String> {
         if (stringSet != null && lastUpdate >= thisRef.kotprefTransactionStartTime) {
             return stringSet!!
         }
-        val prefSet = thisRef.kotprefPreference.getStringSet(key ?: property.name, null)
+        val prefSet = thisRef.kotprefPreference.getStringSet(key ?: propertyName, null)
             ?.let { HashSet(it) }
         stringSet = PrefMutableSet(
             thisRef,
             prefSet ?: default.invoke().toMutableSet(),
-            key ?: property.name
+            key ?: propertyName
         )
         lastUpdate = SystemClock.uptimeMillis()
         return stringSet!!


### PR DESCRIPTION
As of Kotlin 1.3.60, inline property delegation functions are going to be optimized heavily. https://youtrack.jetbrains.com/issue/KT-14513

This PR breaks API for custom delegates. Other ways:
* rework API and stop implementing `ReadWriteProperty`, or
* save API, implement KProperty, override only `name` and pass instances to abstract methods of `AbstractPref`