### PR TITLE
Keep preference key in delegated property

### DIFF
--- a/buildSrc/src/main/java/dependencies/Deps.kt
+++ b/buildSrc/src/main/java/dependencies/Deps.kt
@@ -19,7 +19,6 @@ object Deps {
 
     object Kotlin {
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
-        const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     }
 

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumNullableValuePref.kt
@@ -16,16 +16,16 @@ class EnumNullableValuePref<T : Enum<*>>(
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
-        val value = preference.getString(key ?: property.name, default?.name)
+        val value = preference.getString(preferenceKey, default?.name)
         return enumConstants?.firstOrNull { it.name == value }
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value?.name).execute(commitByDefault)
+        preference.edit().putString(preferenceKey, value?.name).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: T?, editor: SharedPreferences.Editor) {
-        editor.putString(key ?: property.name, value?.name)
+        editor.putString(preferenceKey, value?.name)
     }
 }

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumOrdinalPref.kt
@@ -16,16 +16,16 @@ class EnumOrdinalPref<T : Enum<*>>(
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
-        val value = preference.getInt(key ?: property.name, default.ordinal)
+        val value = preference.getInt(preferenceKey, default.ordinal)
         return enumConstants!!.first { it.ordinal == value }
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
-        preference.edit().putInt(key ?: property.name, value.ordinal).execute(commitByDefault)
+        preference.edit().putInt(preferenceKey, value.ordinal).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
-        editor.putInt(key ?: property.name, value.ordinal)
+        editor.putInt(preferenceKey, value.ordinal)
     }
 }

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumPropertyExtensions.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumPropertyExtensions.kt
@@ -1,7 +1,7 @@
 package com.chibatching.kotpref.enumpref
 
 import com.chibatching.kotpref.KotprefModel
-import kotlin.properties.ReadWriteProperty
+import com.chibatching.kotpref.pref.AbstractPref
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's name as a string.
@@ -12,8 +12,7 @@ inline fun <reified T : Enum<*>> KotprefModel.enumValuePref(
     default: T,
     key: String? = null,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T> =
-    EnumValuePref(T::class, default, key, commitByDefault)
+): AbstractPref<T> = EnumValuePref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's name as a string.
@@ -24,7 +23,7 @@ inline fun <reified T : Enum<*>> KotprefModel.enumValuePref(
     default: T,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T> =
+): AbstractPref<T> =
     EnumValuePref(T::class, default, context.getString(key), commitByDefault)
 
 /**
@@ -36,8 +35,7 @@ inline fun <reified T : Enum<*>> KotprefModel.nullableEnumValuePref(
     default: T? = null,
     key: String? = null,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T?> =
-    EnumNullableValuePref(T::class, default, key, commitByDefault)
+): AbstractPref<T?> = EnumNullableValuePref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's name as a string.
@@ -48,7 +46,7 @@ inline fun <reified T : Enum<*>> KotprefModel.nullableEnumValuePref(
     default: T? = null,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T?> =
+): AbstractPref<T?> =
     EnumNullableValuePref(T::class, default, context.getString(key), commitByDefault)
 
 /**
@@ -64,7 +62,7 @@ inline fun <reified T : Enum<*>> KotprefModel.enumNullableValuePref(
     default: T? = null,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T?> = nullableEnumValuePref(default, key, commitByDefault)
+): AbstractPref<T?> = nullableEnumValuePref(default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's ordinal as an integer.
@@ -75,8 +73,7 @@ inline fun <reified T : Enum<*>> KotprefModel.enumOrdinalPref(
     default: T,
     key: String? = null,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T> =
-    EnumOrdinalPref(T::class, default, key, commitByDefault)
+): AbstractPref<T> = EnumOrdinalPref(T::class, default, key, commitByDefault)
 
 /**
  * Delegate enum-based shared preferences property storing and recalling by the enum value's ordinal as an integer.
@@ -87,5 +84,4 @@ inline fun <reified T : Enum<*>> KotprefModel.enumOrdinalPref(
     default: T,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T> =
-    EnumOrdinalPref(T::class, default, context.getString(key), commitByDefault)
+): AbstractPref<T> = EnumOrdinalPref(T::class, default, context.getString(key), commitByDefault)

--- a/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
+++ b/enum-support/src/main/kotlin/com/chibatching/kotpref/enumpref/EnumValuePref.kt
@@ -16,16 +16,16 @@ class EnumValuePref<T : Enum<*>>(
     private val enumConstants = enumClass.java.enumConstants
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
-        val value = preference.getString(key ?: property.name, default.name)
+        val value = preference.getString(preferenceKey, default.name)
         return enumConstants!!.first { it.name == value }
     }
 
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
-        preference.edit().putString(key ?: property.name, value.name).execute(commitByDefault)
+        preference.edit().putString(preferenceKey, value.name).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
-        editor.putString(key ?: property.name, value.name)
+        editor.putString(preferenceKey, value.name)
     }
 }

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
@@ -16,7 +16,7 @@ class GsonNullablePref<T : Any>(
 ) : AbstractPref<T?>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
-        return preference.getString(key ?: property.name, null)?.let { json ->
+        return preference.getString(preferenceKey, null)?.let { json ->
             deserializeFromJson(json) ?: default
         }
     }
@@ -24,13 +24,13 @@ class GsonNullablePref<T : Any>(
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T?, preference: SharedPreferences) {
         serializeToJson(value).let { json ->
-            preference.edit().putString(key ?: property.name, json).execute(commitByDefault)
+            preference.edit().putString(preferenceKey, json).execute(commitByDefault)
         }
     }
 
     override fun setToEditor(property: KProperty<*>, value: T?, editor: SharedPreferences.Editor) {
         serializeToJson(value).let { json ->
-            editor.putString(key ?: property.name, json)
+            editor.putString(preferenceKey, json)
         }
     }
 

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
@@ -16,7 +16,7 @@ class GsonPref<T : Any>(
 ) : AbstractPref<T>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
-        return preference.getString(key ?: property.name, null)?.let { json ->
+        return preference.getString(preferenceKey, null)?.let { json ->
             deserializeFromJson(json) ?: default
         } ?: default
     }
@@ -24,13 +24,13 @@ class GsonPref<T : Any>(
     @SuppressLint("CommitPrefEdits")
     override fun setToPreference(property: KProperty<*>, value: T, preference: SharedPreferences) {
         serializeToJson(value).let { json ->
-            preference.edit().putString(key ?: property.name, json).execute(commitByDefault)
+            preference.edit().putString(preferenceKey, json).execute(commitByDefault)
         }
     }
 
     override fun setToEditor(property: KProperty<*>, value: T, editor: SharedPreferences.Editor) {
         serializeToJson(value).let { json ->
-            editor.putString(key ?: property.name, json)
+            editor.putString(preferenceKey, json)
         }
     }
 

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/KotprefGsonExtentions.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/KotprefGsonExtentions.kt
@@ -2,9 +2,9 @@ package com.chibatching.kotpref.gsonpref
 
 import com.chibatching.kotpref.Kotpref
 import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.pref.AbstractPref
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import kotlin.properties.ReadWriteProperty
 
 /**
  * Gson object to serialize and deserialize delegated property
@@ -26,8 +26,7 @@ inline fun <reified T : Any> KotprefModel.gsonPref(
     default: T,
     key: String? = null,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T> =
-    GsonPref(object : TypeToken<T>() {}.type, default, key, commitByDefault)
+): AbstractPref<T> = GsonPref(object : TypeToken<T>() {}.type, default, key, commitByDefault)
 
 /**
  * Delegate shared preferences property serialized and deserialized by gson
@@ -38,7 +37,7 @@ inline fun <reified T : Any> KotprefModel.gsonPref(
     default: T,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T> =
+): AbstractPref<T> =
     GsonPref(object : TypeToken<T>() {}.type, default, context.getString(key), commitByDefault)
 
 /**
@@ -50,7 +49,7 @@ inline fun <reified T : Any> KotprefModel.gsonNullablePref(
     default: T? = null,
     key: String? = null,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T?> =
+): AbstractPref<T?> =
     GsonNullablePref(object : TypeToken<T>() {}.type, default, key, commitByDefault)
 
 /**
@@ -62,7 +61,7 @@ inline fun <reified T : Any> KotprefModel.gsonNullablePref(
     default: T? = null,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
-): ReadWriteProperty<KotprefModel, T?> = GsonNullablePref(
+): AbstractPref<T?> = GsonNullablePref(
     object : TypeToken<T>() {}.type,
     default,
     context.getString(key),

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/KotprefModel.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.CallSuper
 import com.chibatching.kotpref.pref.AbstractPref
+import com.chibatching.kotpref.pref.AbstractStringSetPref
 import com.chibatching.kotpref.pref.BooleanPref
 import com.chibatching.kotpref.pref.FloatPref
 import com.chibatching.kotpref.pref.IntPref
@@ -17,8 +18,6 @@ import com.chibatching.kotpref.pref.StringNullablePref
 import com.chibatching.kotpref.pref.StringPref
 import com.chibatching.kotpref.pref.StringSetPref
 import java.util.LinkedHashSet
-import kotlin.properties.ReadOnlyProperty
-import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 abstract class KotprefModel(
@@ -113,7 +112,7 @@ abstract class KotprefModel(
         default: String = "",
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, String> =
+    ): AbstractPref<String> =
         stringPref(default, context.getString(key), commitByDefault)
 
     /**
@@ -126,7 +125,7 @@ abstract class KotprefModel(
         default: String? = null,
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, String?> =
+    ): AbstractPref<String?> =
         StringNullablePref(default, key, commitByDefault)
 
     /**
@@ -139,7 +138,7 @@ abstract class KotprefModel(
         default: String? = null,
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, String?> =
+    ): AbstractPref<String?> =
         nullableStringPref(default, context.getString(key), commitByDefault)
 
     /**
@@ -152,7 +151,7 @@ abstract class KotprefModel(
         default: Int = 0,
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Int> = IntPref(default, key, commitByDefault)
+    ): AbstractPref<Int> = IntPref(default, key, commitByDefault)
 
     /**
      * Delegate int shared preferences property.
@@ -164,7 +163,7 @@ abstract class KotprefModel(
         default: Int = 0,
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Int> =
+    ): AbstractPref<Int> =
         intPref(default, context.getString(key), commitByDefault)
 
     /**
@@ -177,7 +176,7 @@ abstract class KotprefModel(
         default: Long = 0L,
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Long> = LongPref(default, key, commitByDefault)
+    ): AbstractPref<Long> = LongPref(default, key, commitByDefault)
 
     /**
      * Delegate long shared preferences property.
@@ -189,8 +188,7 @@ abstract class KotprefModel(
         default: Long = 0L,
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Long> =
-        longPref(default, context.getString(key), commitByDefault)
+    ): AbstractPref<Long> = longPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate float shared preferences property.
@@ -202,8 +200,7 @@ abstract class KotprefModel(
         default: Float = 0F,
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ):
-        ReadWriteProperty<KotprefModel, Float> = FloatPref(default, key, commitByDefault)
+    ): AbstractPref<Float> = FloatPref(default, key, commitByDefault)
 
     /**
      * Delegate float shared preferences property.
@@ -215,8 +212,7 @@ abstract class KotprefModel(
         default: Float = 0F,
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Float> =
-        floatPref(default, context.getString(key), commitByDefault)
+    ): AbstractPref<Float> = floatPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate boolean shared preferences property.
@@ -228,8 +224,7 @@ abstract class KotprefModel(
         default: Boolean = false,
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Boolean> =
-        BooleanPref(default, key, commitByDefault)
+    ): AbstractPref<Boolean> = BooleanPref(default, key, commitByDefault)
 
     /**
      * Delegate boolean shared preferences property.
@@ -241,8 +236,7 @@ abstract class KotprefModel(
         default: Boolean = false,
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadWriteProperty<KotprefModel, Boolean> =
-        booleanPref(default, context.getString(key), commitByDefault)
+    ): AbstractPref<Boolean> = booleanPref(default, context.getString(key), commitByDefault)
 
     /**
      * Delegate string set shared preferences property.
@@ -252,11 +246,10 @@ abstract class KotprefModel(
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     protected fun stringSetPref(
-        default: Set<String> = LinkedHashSet<String>(),
+        default: Set<String> = LinkedHashSet(),
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> =
-        stringSetPref(key, commitByDefault) { default }
+    ): AbstractStringSetPref = stringSetPref(key, commitByDefault) { default }
 
     /**
      * Delegate string set shared preferences property.
@@ -269,8 +262,7 @@ abstract class KotprefModel(
         default: Set<String> = LinkedHashSet<String>(),
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault
-    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> =
-        stringSetPref(context.getString(key), commitByDefault) { default }
+    ): AbstractStringSetPref = stringSetPref(context.getString(key), commitByDefault) { default }
 
     /**
      * Delegate string set shared preferences property.
@@ -283,8 +275,7 @@ abstract class KotprefModel(
         key: String? = null,
         commitByDefault: Boolean = commitAllPropertiesByDefault,
         default: () -> Set<String>
-    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> =
-        StringSetPref(default, key, commitByDefault)
+    ): AbstractStringSetPref = StringSetPref(default, key, commitByDefault)
 
     /**
      * Delegate string set shared preferences property.
@@ -297,8 +288,7 @@ abstract class KotprefModel(
         key: Int,
         commitByDefault: Boolean = commitAllPropertiesByDefault,
         default: () -> Set<String>
-    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> =
-        stringSetPref(context.getString(key), commitByDefault, default)
+    ): AbstractStringSetPref = stringSetPref(context.getString(key), commitByDefault, default)
 
     /**
      * Begin bulk edit mode. You must commit or cancel after bulk edit finished.

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/AbstractPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/AbstractPref.kt
@@ -6,12 +6,29 @@ import com.chibatching.kotpref.KotprefModel
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-abstract class AbstractPref<T : Any?> : ReadWriteProperty<KotprefModel, T>, PreferenceKey {
+abstract class AbstractPref<T : Any?> : ReadWriteProperty<KotprefModel, T>, PreferenceProperty {
 
     private var lastUpdate: Long = 0
     private var transactionData: Any? = null
 
-    abstract override val key: String?
+    abstract val key: String?
+
+    private lateinit var property: KProperty<*>
+
+    override val propertyName: String
+        get() = property.name
+
+    override val preferenceKey: String
+        get() = key ?: property.name
+
+    operator fun provideDelegate(
+        thisRef: KotprefModel,
+        property: KProperty<*>
+    ): ReadWriteProperty<KotprefModel, T> {
+        this.property = property
+        thisRef.kotprefProperties[property.name] = this
+        return this
+    }
 
     override operator fun getValue(thisRef: KotprefModel, property: KProperty<*>): T {
         if (!thisRef.kotprefInTransaction) {

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/AbstractStringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/AbstractStringSetPref.kt
@@ -1,0 +1,29 @@
+package com.chibatching.kotpref.pref
+
+import com.chibatching.kotpref.KotprefModel
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+abstract class AbstractStringSetPref :
+    ReadOnlyProperty<KotprefModel, MutableSet<String>>,
+    PreferenceProperty {
+
+    abstract val key: String?
+
+    private lateinit var property: KProperty<*>
+
+    override val propertyName: String
+        get() = property.name
+
+    override val preferenceKey: String
+        get() = key ?: property.name
+
+    operator fun provideDelegate(
+        thisRef: KotprefModel,
+        property: KProperty<*>
+    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> {
+        this.property = property
+        thisRef.kotprefProperties[property.name] = this
+        return this
+    }
+}

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/BooleanPref.kt
@@ -12,7 +12,7 @@ internal class BooleanPref(
 ) : AbstractPref<Boolean>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Boolean {
-        return preference.getBoolean(key ?: property.name, default)
+        return preference.getBoolean(preferenceKey, default)
     }
 
     @SuppressLint("CommitPrefEdits")
@@ -21,7 +21,7 @@ internal class BooleanPref(
         value: Boolean,
         preference: SharedPreferences
     ) {
-        preference.edit().putBoolean(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putBoolean(preferenceKey, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
@@ -29,6 +29,6 @@ internal class BooleanPref(
         value: Boolean,
         editor: SharedPreferences.Editor
     ) {
-        editor.putBoolean(key ?: property.name, value)
+        editor.putBoolean(preferenceKey, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/FloatPref.kt
@@ -12,7 +12,7 @@ internal class FloatPref(
 ) : AbstractPref<Float>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Float {
-        return preference.getFloat(key ?: property.name, default)
+        return preference.getFloat(preferenceKey, default)
     }
 
     @SuppressLint("CommitPrefEdits")
@@ -21,7 +21,7 @@ internal class FloatPref(
         value: Float,
         preference: SharedPreferences
     ) {
-        preference.edit().putFloat(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putFloat(preferenceKey, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
@@ -29,6 +29,6 @@ internal class FloatPref(
         value: Float,
         editor: SharedPreferences.Editor
     ) {
-        editor.putFloat(key ?: property.name, value)
+        editor.putFloat(preferenceKey, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/IntPref.kt
@@ -12,7 +12,7 @@ internal class IntPref(
 ) : AbstractPref<Int>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Int {
-        return preference.getInt(key ?: property.name, default)
+        return preference.getInt(preferenceKey, default)
     }
 
     @SuppressLint("CommitPrefEdits")
@@ -21,10 +21,10 @@ internal class IntPref(
         value: Int,
         preference: SharedPreferences
     ) {
-        preference.edit().putInt(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putInt(preferenceKey, value).execute(commitByDefault)
     }
 
     override fun setToEditor(property: KProperty<*>, value: Int, editor: SharedPreferences.Editor) {
-        editor.putInt(key ?: property.name, value)
+        editor.putInt(preferenceKey, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/LongPref.kt
@@ -12,7 +12,7 @@ internal class LongPref(
 ) : AbstractPref<Long>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): Long {
-        return preference.getLong(key ?: property.name, default)
+        return preference.getLong(preferenceKey, default)
     }
 
     @SuppressLint("CommitPrefEdits")
@@ -21,7 +21,7 @@ internal class LongPref(
         value: Long,
         preference: SharedPreferences
     ) {
-        preference.edit().putLong(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putLong(preferenceKey, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
@@ -29,6 +29,6 @@ internal class LongPref(
         value: Long,
         editor: SharedPreferences.Editor
     ) {
-        editor.putLong(key ?: property.name, value)
+        editor.putLong(preferenceKey, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/PreferenceKey.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/PreferenceKey.kt
@@ -1,5 +1,0 @@
-package com.chibatching.kotpref.pref
-
-interface PreferenceKey {
-    val key: String?
-}

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/PreferenceProperty.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/PreferenceProperty.kt
@@ -1,0 +1,6 @@
+package com.chibatching.kotpref.pref
+
+interface PreferenceProperty {
+    val propertyName: String
+    val preferenceKey: String
+}

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringNullablePref.kt
@@ -12,7 +12,7 @@ internal class StringNullablePref(
 ) : AbstractPref<String?>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String? {
-        return preference.getString(key ?: property.name, default)
+        return preference.getString(preferenceKey, default)
     }
 
     @SuppressLint("CommitPrefEdits")
@@ -21,7 +21,7 @@ internal class StringNullablePref(
         value: String?,
         preference: SharedPreferences
     ) {
-        preference.edit().putString(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putString(preferenceKey, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
@@ -29,6 +29,6 @@ internal class StringNullablePref(
         value: String?,
         editor: SharedPreferences.Editor
     ) {
-        editor.putString(key ?: property.name, value)
+        editor.putString(preferenceKey, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringPref.kt
@@ -12,7 +12,7 @@ internal class StringPref(
 ) : AbstractPref<String>() {
 
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): String {
-        return requireNotNull(preference.getString(key ?: property.name, default))
+        return requireNotNull(preference.getString(preferenceKey, default))
     }
 
     @SuppressLint("CommitPrefEdits")
@@ -21,7 +21,7 @@ internal class StringPref(
         value: String,
         preference: SharedPreferences
     ) {
-        preference.edit().putString(key ?: property.name, value).execute(commitByDefault)
+        preference.edit().putString(preferenceKey, value).execute(commitByDefault)
     }
 
     override fun setToEditor(
@@ -29,6 +29,6 @@ internal class StringPref(
         value: String,
         editor: SharedPreferences.Editor
     ) {
-        editor.putString(key ?: property.name, value)
+        editor.putString(preferenceKey, value)
     }
 }

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
@@ -6,35 +6,17 @@ import android.os.Build
 import android.os.SystemClock
 import com.chibatching.kotpref.KotprefModel
 import com.chibatching.kotpref.execute
-import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 internal class StringSetPref(
     val default: () -> Set<String>,
-    val key: String?,
+    override val key: String?,
     private val commitByDefault: Boolean
-) : ReadOnlyProperty<KotprefModel, MutableSet<String>>, PreferenceProperty {
+) : AbstractStringSetPref() {
 
     private var stringSet: MutableSet<String>? = null
     private var lastUpdate: Long = 0L
-
-    private lateinit var property: KProperty<*>
-
-    override val propertyName: String
-        get() = property.name
-
-    override val preferenceKey: String
-        get() = key ?: property.name
-
-    operator fun provideDelegate(
-        thisRef: KotprefModel,
-        property: KProperty<*>
-    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> {
-        this.property = property
-        thisRef.kotprefProperties[property.name] = this
-        return this
-    }
 
     override operator fun getValue(
         thisRef: KotprefModel,
@@ -43,12 +25,12 @@ internal class StringSetPref(
         if (stringSet != null && lastUpdate >= thisRef.kotprefTransactionStartTime) {
             return stringSet!!
         }
-        val prefSet = thisRef.kotprefPreference.getStringSet(key ?: property.name, null)
+        val prefSet = thisRef.kotprefPreference.getStringSet(preferenceKey, null)
             ?.let { HashSet(it) }
         stringSet = PrefMutableSet(
             thisRef,
             prefSet ?: default.invoke().toMutableSet(),
-            key ?: property.name
+            preferenceKey
         )
         lastUpdate = SystemClock.uptimeMillis()
         return stringSet!!

--- a/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
+++ b/kotpref/src/main/kotlin/com/chibatching/kotpref/pref/StringSetPref.kt
@@ -12,12 +12,29 @@ import kotlin.reflect.KProperty
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 internal class StringSetPref(
     val default: () -> Set<String>,
-    override val key: String?,
+    val key: String?,
     private val commitByDefault: Boolean
-) : ReadOnlyProperty<KotprefModel, MutableSet<String>>, PreferenceKey {
+) : ReadOnlyProperty<KotprefModel, MutableSet<String>>, PreferenceProperty {
 
     private var stringSet: MutableSet<String>? = null
     private var lastUpdate: Long = 0L
+
+    private lateinit var property: KProperty<*>
+
+    override val propertyName: String
+        get() = property.name
+
+    override val preferenceKey: String
+        get() = key ?: property.name
+
+    operator fun provideDelegate(
+        thisRef: KotprefModel,
+        property: KProperty<*>
+    ): ReadOnlyProperty<KotprefModel, MutableSet<String>> {
+        this.property = property
+        thisRef.kotprefProperties[property.name] = this
+        return this
+    }
 
     override operator fun getValue(
         thisRef: KotprefModel,

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.Arch.liveData
     testImplementation Deps.Arch.runtime
+    testImplementation Deps.gson
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     testImplementation Deps.AndroidX.testCore

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -46,10 +46,8 @@ dependencies {
     api project(":kotpref")
 
     compileOnly Deps.Arch.liveData
-    compileOnly Deps.Kotlin.reflect
 
     testImplementation Deps.Kotlin.stdlib
-    testImplementation Deps.Kotlin.reflect
     testImplementation Deps.Arch.liveData
     testImplementation Deps.Arch.runtime
     testImplementation Deps.junit

--- a/livedata-support/build.gradle
+++ b/livedata-support/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
     compileOnly Deps.Arch.liveData
 
+    testImplementation project(":gson-support")
+    testImplementation project(":enum-support")
     testImplementation Deps.Kotlin.stdlib
     testImplementation Deps.Arch.liveData
     testImplementation Deps.Arch.runtime

--- a/livedata-support/src/main/kotlin/com/chibatching/kotpref/livedata/KotprefLiveDataExtensions.kt
+++ b/livedata-support/src/main/kotlin/com/chibatching/kotpref/livedata/KotprefLiveDataExtensions.kt
@@ -3,19 +3,15 @@ package com.chibatching.kotpref.livedata
 import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import com.chibatching.kotpref.KotprefModel
-import com.chibatching.kotpref.pref.PreferenceKey
 import kotlin.reflect.KProperty0
-import kotlin.reflect.jvm.isAccessible
 
 fun <T> KotprefModel.asLiveData(property: KProperty0<T>): LiveData<T> {
     return object : LiveData<T>(), SharedPreferences.OnSharedPreferenceChangeListener {
-        private val key: String
+        private val key: String = this@asLiveData.getPrefKey(property)
+            ?: throw IllegalArgumentException("Failed to get preference key, check property ${property.name} is delegated to Kotpref")
 
         init {
-            value = property.get()
-            property.isAccessible = true
-            key = (property.getDelegate() as? PreferenceKey)?.key ?: property.name
-            property.isAccessible = false
+            postValue(property.get())
         }
 
         override fun onSharedPreferenceChanged(prefs: SharedPreferences, propertyName: String) {

--- a/livedata-support/src/test/java/com/chibatching/kotpref/livedata/Example.kt
+++ b/livedata-support/src/test/java/com/chibatching/kotpref/livedata/Example.kt
@@ -1,0 +1,20 @@
+package com.chibatching.kotpref.livedata
+
+import android.content.Context
+import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.enumpref.enumValuePref
+import com.chibatching.kotpref.gsonpref.gsonPref
+
+class Example(context: Context) : KotprefModel(context) {
+    companion object {
+        val gsonSampleDefault = LiveDataSupportTest.GsonSample("text", 1)
+        val defaultSet = setOf("test1", "test2")
+    }
+
+    var someProperty by stringPref("default")
+    var customKeyProperty by intPref(8, "custom_key")
+
+    var gsonPref by gsonPref(gsonSampleDefault)
+    var enumPref by enumValuePref(LiveDataSupportTest.EnumSample.FIRST)
+    val setPref by stringSetPref(defaultSet)
+}

--- a/livedata-support/src/test/java/com/chibatching/kotpref/livedata/LiveDataSupportTest.kt
+++ b/livedata-support/src/test/java/com/chibatching/kotpref/livedata/LiveDataSupportTest.kt
@@ -1,15 +1,12 @@
 package com.chibatching.kotpref.livedata
 
-import android.content.Context
+import android.app.Application
 import android.content.SharedPreferences
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.Observer
 import androidx.test.core.app.ApplicationProvider
-import com.chibatching.kotpref.KotprefModel
-import com.chibatching.kotpref.enumpref.enumValuePref
-import com.chibatching.kotpref.gsonpref.gsonPref
 import com.google.common.truth.Truth.assertThat
 import io.mockk.Runs
 import io.mockk.every
@@ -27,20 +24,6 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class LiveDataSupportTest {
 
-    class Example(context: Context) : KotprefModel(context) {
-        companion object {
-            val gsonSampleDefault = GsonSample("text", 1)
-            val defaultSet = setOf("test1", "test2")
-        }
-
-        var someProperty by stringPref("default")
-        var customKeyProperty by intPref(8, "custom_key")
-
-        var gsonPref by gsonPref(gsonSampleDefault)
-        var enumPref by enumValuePref(EnumSample.FIRST)
-        val setPref by stringSetPref(defaultSet)
-    }
-
     data class GsonSample(
         val text: String,
         val number: Int
@@ -57,7 +40,9 @@ class LiveDataSupportTest {
 
     @Before
     fun setUp() {
-        example = Example(ApplicationProvider.getApplicationContext())
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        example =
+            Example(context)
 
         pref = example.preferences
         pref.edit().clear().commit()

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     // LiveData support
     implementation project(":livedata-support")
     implementation Deps.Arch.liveData
-    implementation Deps.Kotlin.reflect
 
     // For test
     testImplementation Deps.junit


### PR DESCRIPTION
To remove reflection, keep preference key and property name in delegated property.