### PR TITLE
Add constructor to GsonPref to provide default value lazily

### DIFF
--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonNullablePref.kt
@@ -10,14 +10,21 @@ import kotlin.reflect.KProperty
 
 class GsonNullablePref<T : Any>(
     private val targetType: Type,
-    private val default: T?,
+    private val default: (() -> T?),
     override val key: String?,
     private val commitByDefault: Boolean
 ) : AbstractPref<T?>() {
 
+    constructor(
+        targetType: Type,
+        default: T?,
+        key: String?,
+        commitByDefault: Boolean
+    ) : this(targetType, { default }, key, commitByDefault)
+
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T? {
         return preference.getString(preferenceKey, null)?.let { json ->
-            deserializeFromJson(json) ?: default
+            deserializeFromJson(json) ?: default.invoke()
         }
     }
 

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/GsonPref.kt
@@ -10,15 +10,24 @@ import kotlin.reflect.KProperty
 
 class GsonPref<T : Any>(
     private val targetType: Type,
-    private val default: T,
+    private val default: () -> T,
     override val key: String?,
     private val commitByDefault: Boolean
 ) : AbstractPref<T>() {
 
+    constructor(
+        targetType: Type,
+        default: T,
+        key: String?,
+        commitByDefault: Boolean
+    ) : this(
+        targetType, { default }, key, commitByDefault
+    )
+
     override fun getFromPreference(property: KProperty<*>, preference: SharedPreferences): T {
         return preference.getString(preferenceKey, null)?.let { json ->
-            deserializeFromJson(json) ?: default
-        } ?: default
+            deserializeFromJson(json) ?: default()
+        } ?: default()
     }
 
     @SuppressLint("CommitPrefEdits")

--- a/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/KotprefGsonExtentions.kt
+++ b/gson-support/src/main/kotlin/com/chibatching/kotpref/gsonpref/KotprefGsonExtentions.kt
@@ -30,6 +30,17 @@ inline fun <reified T : Any> KotprefModel.gsonPref(
 
 /**
  * Delegate shared preferences property serialized and deserialized by gson
+ * @param default default gson object value provider function
+ * @param key custom preferences key
+ */
+inline fun <reified T : Any> KotprefModel.gsonPref(
+    key: String? = null,
+    commitByDefault: Boolean = commitAllPropertiesByDefault,
+    noinline default: () -> T
+): AbstractPref<T> = GsonPref(object : TypeToken<T>() {}.type, default, key, commitByDefault)
+
+/**
+ * Delegate shared preferences property serialized and deserialized by gson
  * @param default default gson object value
  * @param key custom preferences key resource id
  */
@@ -37,6 +48,18 @@ inline fun <reified T : Any> KotprefModel.gsonPref(
     default: T,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
+): AbstractPref<T> =
+    GsonPref(object : TypeToken<T>() {}.type, default, context.getString(key), commitByDefault)
+
+/**
+ * Delegate shared preferences property serialized and deserialized by gson
+ * @param default default gson object value provider function
+ * @param key custom preferences key resource id
+ */
+inline fun <reified T : Any> KotprefModel.gsonPref(
+    key: Int,
+    commitByDefault: Boolean = commitAllPropertiesByDefault,
+    noinline default: () -> T
 ): AbstractPref<T> =
     GsonPref(object : TypeToken<T>() {}.type, default, context.getString(key), commitByDefault)
 
@@ -54,6 +77,18 @@ inline fun <reified T : Any> KotprefModel.gsonNullablePref(
 
 /**
  * Delegate shared preferences property serialized and deserialized by gson
+ * @param default default gson object value provider function
+ * @param key custom preferences key
+ */
+inline fun <reified T : Any> KotprefModel.gsonNullablePref(
+    key: String? = null,
+    commitByDefault: Boolean = commitAllPropertiesByDefault,
+    noinline default: (() -> T?)
+): AbstractPref<T?> =
+    GsonNullablePref(object : TypeToken<T>() {}.type, default, key, commitByDefault)
+
+/**
+ * Delegate shared preferences property serialized and deserialized by gson
  * @param default default gson object value
  * @param key custom preferences key resource id
  */
@@ -61,6 +96,22 @@ inline fun <reified T : Any> KotprefModel.gsonNullablePref(
     default: T? = null,
     key: Int,
     commitByDefault: Boolean = commitAllPropertiesByDefault
+): AbstractPref<T?> = GsonNullablePref(
+    object : TypeToken<T>() {}.type,
+    default,
+    context.getString(key),
+    commitByDefault
+)
+
+/**
+ * Delegate shared preferences property serialized and deserialized by gson
+ * @param default default gson object value provider function
+ * @param key custom preferences key resource id
+ */
+inline fun <reified T : Any> KotprefModel.gsonNullablePref(
+    key: Int,
+    commitByDefault: Boolean = commitAllPropertiesByDefault,
+    noinline default: (() -> T?)
 ): AbstractPref<T?> = GsonNullablePref(
     object : TypeToken<T>() {}.type,
     default,

--- a/gson-support/src/test/java/com/chibatching/kotpref/gsonpref/GsonSupportTest.kt
+++ b/gson-support/src/test/java/com/chibatching/kotpref/gsonpref/GsonSupportTest.kt
@@ -47,9 +47,9 @@ class GsonSupportTest(private val commitAllProperties: Boolean) {
 
         var content by gsonPref(createDefaultContent())
 
-        var list: List<String> by gsonPref(emptyList())
+        var list: List<String> by gsonPref(emptyList<String>())
 
-        var nullableContent: Content? by gsonNullablePref()
+        var nullableContent: Content? by gsonNullablePref<Content>()
     }
 
     private lateinit var example: Example


### PR DESCRIPTION
To instantiate gson pref default value lazily, add constructor of default value provider function.

```kotlin
val immediatelySample: User by gsonPref(default = User()) // instantiate immediately
val lazySample: User by gsonPref() { User() } // instantiate when needed
```