### PR TITLE
Add dsl for Preference

### DIFF
--- a/preference-screen-dsl/src/main/kotlin/com/chibatching/kotpref/preference/dsl/KotprefPreferenceExtension.kt
+++ b/preference-screen-dsl/src/main/kotlin/com/chibatching/kotpref/preference/dsl/KotprefPreferenceExtension.kt
@@ -187,6 +187,23 @@ class PreferenceScreenBuilder(
     }
 
     /**
+     * Create [Preference]
+     */
+    fun preference(
+        key: String,
+        title: String,
+        options: (Preference.() -> Unit)? = null
+    ): Preference {
+        val preference = Preference(context).apply {
+            this.key = key
+            this.title = title
+            options?.invoke(this)
+        }
+        rootScreen.addPreference(preference)
+        return preference
+    }
+
+    /**
      * Create [PreferenceCategory]
      * @param title category title
      * @param childBuilder [PreferenceScreenBuilder] to create Preference in this category

--- a/preference-screen-dsl/src/main/kotlin/com/chibatching/kotpref/preference/dsl/KotprefPreferenceExtension.kt
+++ b/preference-screen-dsl/src/main/kotlin/com/chibatching/kotpref/preference/dsl/KotprefPreferenceExtension.kt
@@ -41,8 +41,8 @@ fun <T : KotprefModel> PreferenceFragmentCompat.kotprefScreen(
 
     val rootScreen: PreferenceScreen = preferenceManager.createPreferenceScreen(themedContext)
     val preferenceBuilder = PreferenceScreenBuilder(themedContext, rootScreen, model)
-    builder(preferenceBuilder, model)
     preferenceScreen = rootScreen
+    builder(preferenceBuilder, model)
     preferenceBuilder.dependencyBuilder.build()
 }
 

--- a/sample/src/main/kotlin/com/chibatching/kotprefsample/preferencedsl/PreferenceScreenDslSampleFragment.kt
+++ b/sample/src/main/kotlin/com/chibatching/kotprefsample/preferencedsl/PreferenceScreenDslSampleFragment.kt
@@ -96,6 +96,10 @@ class PreferenceScreenDslSampleFragment : PreferenceFragmentCompat() {
                     max = 100
                     this.showSeekBarValue = true
                 }
+
+                preference("samplePreference", "Sample preference") {
+                    summary = "This preference does nothing"
+                }
             }
 
             category("Info") {


### PR DESCRIPTION
Hi, I recently started using the preference screen dsl and it's awesome, thanks for that.
I encountered one problem though - I needed simple `Preference` with custom layout and there was no function for that. It makes kinda sense since it is not bound to kotpref property, but it will still be nice to have it, I think. I tried to create the Preference on my own then, but since the `preferenceScreen` is only set after calling the builder function, there is no way to use it to add the `Preference` to the screen from within that function, or at least I can't see it.

So I created a function for building the `Preference` and moved the assignment so one can access the `preferenceScreen` in the builder function to do any custom stuff.